### PR TITLE
Add `source` fields to error variants for invalid utf-8

### DIFF
--- a/src/cmd_output.rs
+++ b/src/cmd_output.rs
@@ -1,5 +1,5 @@
 use crate::{Config, Error, RunResult};
-use std::process::ExitStatus;
+use std::{process::ExitStatus, sync::Arc};
 
 /// All possible return types of [`cmd!`] have to implement this trait.
 /// For documentation about what these return types do, see the
@@ -97,7 +97,7 @@ impl CmdOutput for StdoutUntrimmed {
         Ok(StdoutUntrimmed(String::from_utf8(result.stdout).map_err(
             |source| Error::InvalidUtf8ToStdout {
                 full_command: config.full_command(),
-                source,
+                source: Arc::new(source),
             },
         )?))
     }
@@ -201,7 +201,7 @@ impl CmdOutput for Stderr {
         Ok(Stderr(String::from_utf8(result?.stderr).map_err(
             |source| Error::InvalidUtf8ToStderr {
                 full_command: config.full_command(),
-                source,
+                source: Arc::new(source),
             },
         )?))
     }

--- a/src/cmd_output.rs
+++ b/src/cmd_output.rs
@@ -1,5 +1,5 @@
 use crate::{Config, Error, RunResult};
-use std::{process::ExitStatus, sync::Arc};
+use std::process::ExitStatus;
 
 /// All possible return types of [`cmd!`] have to implement this trait.
 /// For documentation about what these return types do, see the
@@ -97,7 +97,7 @@ impl CmdOutput for StdoutUntrimmed {
         Ok(StdoutUntrimmed(String::from_utf8(result.stdout).map_err(
             |source| Error::InvalidUtf8ToStdout {
                 full_command: config.full_command(),
-                source: Arc::new(source),
+                source,
             },
         )?))
     }
@@ -201,7 +201,7 @@ impl CmdOutput for Stderr {
         Ok(Stderr(String::from_utf8(result?.stderr).map_err(
             |source| Error::InvalidUtf8ToStderr {
                 full_command: config.full_command(),
-                source: Arc::new(source),
+                source,
             },
         )?))
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,11 +14,11 @@ pub enum Error {
     },
     InvalidUtf8ToStdout {
         full_command: String,
-        source: FromUtf8Error,
+        source: Arc<FromUtf8Error>,
     },
     InvalidUtf8ToStderr {
         full_command: String,
-        source: FromUtf8Error,
+        source: Arc<FromUtf8Error>,
     },
 }
 
@@ -63,7 +63,7 @@ impl std::error::Error for Error {
         match self {
             Error::CommandIoError { source, .. } => Some(&**source),
             Error::InvalidUtf8ToStdout { source, .. }
-            | Error::InvalidUtf8ToStderr { source, .. } => Some(source),
+            | Error::InvalidUtf8ToStderr { source, .. } => Some(&**source),
             Error::NoArgumentsGiven | Error::NonZeroExitCode { .. } => None,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,11 +14,11 @@ pub enum Error {
     },
     InvalidUtf8ToStdout {
         full_command: String,
-        source: Arc<FromUtf8Error>,
+        source: FromUtf8Error,
     },
     InvalidUtf8ToStderr {
         full_command: String,
-        source: Arc<FromUtf8Error>,
+        source: FromUtf8Error,
     },
 }
 
@@ -63,7 +63,7 @@ impl std::error::Error for Error {
         match self {
             Error::CommandIoError { source, .. } => Some(&**source),
             Error::InvalidUtf8ToStdout { source, .. }
-            | Error::InvalidUtf8ToStderr { source, .. } => Some(&**source),
+            | Error::InvalidUtf8ToStderr { source, .. } => Some(source),
             Error::NoArgumentsGiven | Error::NonZeroExitCode { .. } => None,
         }
     }


### PR DESCRIPTION
Fixes #43.