### PR TITLE
Avoid cloning Config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,6 @@
 use std::{ffi::OsString, path::PathBuf};
 
 #[doc(hidden)]
-#[derive(Clone)]
 pub struct Config {
     pub(crate) arguments: Vec<OsString>,
     pub(crate) log_command: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,7 +298,7 @@ where
         .map_err(|error| Error::command_io_error(&config, error))?;
     let waiter = Waiter::spawn_standard_stream_relaying(
         &context,
-        config.clone(),
+        &config,
         child
             .stdout
             .take()


### PR DESCRIPTION
This avoids a couple clones of the `Config` struct. Definitely a micro optimization, but the code is a little nicer too.