### PR TITLE
Add CmdArgument impls for OsString and OsStr

### DIFF
--- a/src/cmd_argument.rs
+++ b/src/cmd_argument.rs
@@ -1,5 +1,6 @@
 use crate::config::Config;
 use std::{
+    ffi::{OsStr, OsString},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -21,12 +22,30 @@ where
     }
 }
 
+/// Arguments of type [`OsString`] are passed to the child process
+/// as arguments.
+impl CmdArgument for OsString {
+    #[doc(hidden)]
+    fn prepare_config(self, config: &mut Config) {
+        config.arguments.push(self);
+    }
+}
+
+/// Arguments of type [`OsStr`] are passed to the child process
+/// as arguments.
+impl CmdArgument for &OsStr {
+    #[doc(hidden)]
+    fn prepare_config(self, config: &mut Config) {
+        self.to_os_string().prepare_config(config);
+    }
+}
+
 /// Arguments of type [`&str`] are passed to the child process
 /// as arguments.
 impl CmdArgument for &str {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
-        config.arguments.push(self.into());
+        OsStr::new(self).prepare_config(config);
     }
 }
 
@@ -35,7 +54,7 @@ impl CmdArgument for &str {
 impl CmdArgument for String {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
-        config.arguments.push(self.into());
+        OsString::from(self).prepare_config(config);
     }
 }
 
@@ -252,7 +271,7 @@ where
 impl CmdArgument for PathBuf {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
-        config.arguments.push(self.into());
+        self.into_os_string().prepare_config(config);
     }
 }
 
@@ -271,7 +290,7 @@ impl CmdArgument for PathBuf {
 impl CmdArgument for &Path {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
-        self.to_path_buf().prepare_config(config);
+        self.as_os_str().to_os_string().prepare_config(config);
     }
 }
 

--- a/src/cmd_argument.rs
+++ b/src/cmd_argument.rs
@@ -24,6 +24,12 @@ where
 
 /// Arguments of type [`OsString`] are passed to the child process
 /// as arguments.
+///
+/// ```
+/// use cradle::*;
+///
+/// cmd_unit!("echo", std::env::var_os("PATH").unwrap());
+/// ```
 impl CmdArgument for OsString {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
@@ -33,6 +39,12 @@ impl CmdArgument for OsString {
 
 /// Arguments of type [`OsStr`] are passed to the child process
 /// as arguments.
+///
+/// ```
+/// use cradle::*;
+///
+/// cmd_unit!("echo", std::env::current_dir().unwrap().file_name().unwrap());
+/// ```
 impl CmdArgument for &OsStr {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {

--- a/src/cmd_argument.rs
+++ b/src/cmd_argument.rs
@@ -37,7 +37,7 @@ impl CmdArgument for OsString {
     }
 }
 
-/// Arguments of type [`OsStr`] are passed to the child process
+/// Arguments of type [`&OsStr`] are passed to the child process
 /// as arguments.
 ///
 /// ```
@@ -45,6 +45,8 @@ impl CmdArgument for OsString {
 ///
 /// cmd_unit!("echo", std::env::current_dir().unwrap().file_name().unwrap());
 /// ```
+///
+/// [`&OsStr`]: std::ffi::OsStr
 impl CmdArgument for &OsStr {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {

--- a/src/cmd_argument.rs
+++ b/src/cmd_argument.rs
@@ -28,7 +28,7 @@ where
 /// ```
 /// use cradle::*;
 ///
-/// cmd_unit!("echo", std::env::var_os("PATH").unwrap());
+/// cmd_unit!("ls", std::env::var_os("HOME").unwrap());
 /// ```
 impl CmdArgument for OsString {
     #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,6 +352,7 @@ mod tests {
     use executable_path::executable_path;
     use std::{
         env::{current_dir, set_current_dir},
+        ffi::OsStr,
         path::PathBuf,
     };
     use tempfile::TempDir;
@@ -748,6 +749,20 @@ mod tests {
                 cmd_unit!("touch", argument);
                 assert!(PathBuf::from("filename with spaces").exists());
             });
+        }
+    }
+
+    mod os_strings {
+        use super::*;
+
+        #[test]
+        fn works_for_os_string() {
+            cmd_unit!(OsString::from("true"));
+        }
+
+        #[test]
+        fn works_for_os_str() {
+            cmd_unit!(OsStr::new("true"));
         }
     }
 


### PR DESCRIPTION
Allows using `OsString` and `&OsStr` as arguments to `cmd`. Among other things, OsString is the type of environment variables and arguments, and `&OsStr` is the type of `Path::file_name`. This diff also changes all `CmdArgument` impls to bottom out in the impl for `OsString`, because that's the actual type of `Config::arguments`.