### PR TITLE
Remove unnecessary conversions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,10 +413,7 @@ mod tests {
             #[test]
             #[should_panic(expected = "exited with exit code: 42")]
             fn other_exit_codes() {
-                cmd_unit!(
-                    executable_path("cradle_test_helper").to_str().unwrap(),
-                    vec!["exit code 42"]
-                );
+                cmd_unit!(executable_path("cradle_test_helper"), vec!["exit code 42"]);
             }
 
             #[test]
@@ -464,7 +461,7 @@ mod tests {
             #[should_panic(expected = "invalid utf-8 written to stdout")]
             fn invalid_utf8_stdout() {
                 let StdoutTrimmed(_) = cmd!(
-                    executable_path("cradle_test_helper").to_str().unwrap(),
+                    executable_path("cradle_test_helper"),
                     vec!["invalid utf-8 stdout"]
                 );
             }
@@ -472,7 +469,7 @@ mod tests {
             #[test]
             fn invalid_utf8_to_stdout_is_allowed_when_not_captured() {
                 cmd_unit!(
-                    executable_path("cradle_test_helper").to_str().unwrap(),
+                    executable_path("cradle_test_helper"),
                     vec!["invalid utf-8 stdout"]
                 );
             }
@@ -536,10 +533,8 @@ mod tests {
 
             #[test]
             fn other_exit_codes() {
-                let result: Result<(), Error> = cmd_result!(
-                    executable_path("cradle_test_helper").to_str().unwrap(),
-                    vec!["exit code 42"]
-                );
+                let result: Result<(), Error> =
+                    cmd_result!(executable_path("cradle_test_helper"), vec!["exit code 42"]);
                 assert!(result
                     .unwrap_err()
                     .to_string()
@@ -569,14 +564,13 @@ mod tests {
             #[test]
             fn invalid_utf8_stdout() {
                 let test_helper = executable_path("cradle_test_helper");
-                let test_helper = test_helper.to_str().unwrap();
                 let result: Result<StdoutTrimmed, Error> =
-                    cmd_result!(test_helper, vec!["invalid utf-8 stdout"]);
+                    cmd_result!(&test_helper, vec!["invalid utf-8 stdout"]);
                 assert_eq!(
                     result.unwrap_err().to_string(),
                     format!(
                         "{} 'invalid utf-8 stdout':\n  invalid utf-8 written to stdout",
-                        test_helper
+                        test_helper.display()
                     )
                 );
             }
@@ -767,7 +761,7 @@ mod tests {
             let context = Context::test();
             let _: Result<(), Error> = cmd_result_with_context!(
                 context.clone(),
-                executable_path("cradle_test_helper").to_str().unwrap(),
+                executable_path("cradle_test_helper"),
                 vec!["output foo and exit with 42"]
             );
             assert_eq!(context.stdout(), "foo\n");
@@ -781,7 +775,7 @@ mod tests {
                 let thread = thread::spawn(|| {
                     cmd_result_with_context_unit!(
                         context_clone,
-                        executable_path("cradle_test_helper").to_str().unwrap(),
+                        executable_path("cradle_test_helper"),
                         vec!["stream chunk then wait for file"]
                     )
                     .unwrap();
@@ -820,7 +814,7 @@ mod tests {
             let context = Context::test();
             cmd_result_with_context_unit!(
                 context.clone(),
-                executable_path("cradle_test_helper").to_str().unwrap(),
+                executable_path("cradle_test_helper"),
                 vec!["write to stderr"]
             )
             .unwrap();
@@ -832,7 +826,7 @@ mod tests {
             let context = Context::test();
             let _: Result<(), Error> = cmd_result_with_context!(
                 context.clone(),
-                executable_path("cradle_test_helper").to_str().unwrap(),
+                executable_path("cradle_test_helper"),
                 vec!["write to stderr and exit with 42"]
             );
             assert_eq!(context.stderr(), "foo\n");
@@ -846,7 +840,7 @@ mod tests {
                 let thread = thread::spawn(|| {
                     cmd_result_with_context_unit!(
                         context_clone,
-                        executable_path("cradle_test_helper").to_str().unwrap(),
+                        executable_path("cradle_test_helper"),
                         vec!["stream chunk to stderr then wait for file"]
                     )
                     .unwrap();
@@ -873,7 +867,7 @@ mod tests {
         #[test]
         fn capture_stderr() {
             let Stderr(stderr) = cmd!(
-                executable_path("cradle_test_helper").to_str().unwrap(),
+                executable_path("cradle_test_helper"),
                 vec!["write to stderr"]
             );
             assert_eq!(stderr, "foo\n");
@@ -882,14 +876,13 @@ mod tests {
         #[test]
         fn assumes_stderr_is_utf_8() {
             let test_helper = executable_path("cradle_test_helper");
-            let test_helper = test_helper.to_str().unwrap();
             let result: Result<Stderr, Error> =
-                cmd_result!(test_helper, vec!["invalid utf-8 stderr"]);
+                cmd_result!(&test_helper, vec!["invalid utf-8 stderr"]);
             assert_eq!(
                 result.unwrap_err().to_string(),
                 format!(
                     "{} 'invalid utf-8 stderr':\n  invalid utf-8 written to stderr",
-                    test_helper
+                    test_helper.display(),
                 )
             );
         }
@@ -897,7 +890,7 @@ mod tests {
         #[test]
         fn does_allow_invalid_utf_8_to_stderr_when_not_capturing() {
             cmd_unit!(
-                executable_path("cradle_test_helper").to_str().unwrap(),
+                executable_path("cradle_test_helper"),
                 vec!["invalid utf-8 stderr"]
             );
         }
@@ -907,7 +900,7 @@ mod tests {
             let context = Context::test();
             let Stderr(_) = cmd_result_with_context!(
                 context.clone(),
-                executable_path("cradle_test_helper").to_str().unwrap(),
+                executable_path("cradle_test_helper"),
                 vec!["write to stderr"]
             )
             .unwrap();
@@ -976,10 +969,8 @@ mod tests {
 
         #[test]
         fn forty_two() {
-            let Exit(exit_status) = cmd!(
-                executable_path("cradle_test_helper").to_str().unwrap(),
-                vec!["exit code 42"]
-            );
+            let Exit(exit_status) =
+                cmd!(executable_path("cradle_test_helper"), vec!["exit code 42"]);
             assert!(!exit_status.success());
             assert_eq!(exit_status.code(), Some(42));
         }
@@ -997,7 +988,7 @@ mod tests {
         #[test]
         fn two_tuple_1() {
             let (StdoutTrimmed(output), Exit(status)) = cmd!(
-                executable_path("cradle_test_helper").to_str().unwrap(),
+                executable_path("cradle_test_helper"),
                 vec!["output foo and exit with 42"]
             );
             assert_eq!(output, "foo");
@@ -1007,7 +998,7 @@ mod tests {
         #[test]
         fn two_tuple_2() {
             let (Exit(status), StdoutTrimmed(output)) = cmd!(
-                executable_path("cradle_test_helper").to_str().unwrap(),
+                executable_path("cradle_test_helper"),
                 vec!["output foo and exit with 42"]
             );
             assert_eq!(output, "foo");
@@ -1039,7 +1030,7 @@ mod tests {
         #[test]
         fn capturing_stdout_on_errors() {
             let (StdoutTrimmed(output), Exit(status)) = cmd!(
-                executable_path("cradle_test_helper").to_str().unwrap(),
+                executable_path("cradle_test_helper"),
                 vec!["output foo and exit with 42"]
             );
             assert!(!status.success());
@@ -1049,7 +1040,7 @@ mod tests {
         #[test]
         fn capturing_stderr_on_errors() {
             let (Stderr(output), Exit(status)) = cmd!(
-                executable_path("cradle_test_helper").to_str().unwrap(),
+                executable_path("cradle_test_helper"),
                 vec!["write to stderr and exit with 42"]
             );
             assert!(!status.success());
@@ -1310,7 +1301,7 @@ mod tests {
         #[test]
         fn allows_to_pass_in_strings_as_stdin() {
             let StdoutUntrimmed(output) = cmd!(
-                executable_path("cradle_test_helper").to_str().unwrap(),
+                executable_path("cradle_test_helper"),
                 "reverse",
                 Stdin("foo")
             );
@@ -1321,7 +1312,7 @@ mod tests {
         #[cfg(unix)]
         fn stdin_is_closed_by_default() {
             let StdoutTrimmed(output) = cmd!(
-                executable_path("cradle_test_helper").to_str().unwrap(),
+                executable_path("cradle_test_helper"),
                 "wait until stdin is closed"
             );
             assert_eq!(output, "stdin is closed");
@@ -1346,7 +1337,7 @@ mod tests {
         #[test]
         fn multiple_stdin_arguments_are_all_passed_into_the_child_process() {
             let StdoutUntrimmed(output) = cmd!(
-                executable_path("cradle_test_helper").to_str().unwrap(),
+                executable_path("cradle_test_helper"),
                 "reverse",
                 Stdin("foo"),
                 Stdin("bar")
@@ -1358,7 +1349,7 @@ mod tests {
         fn works_for_owned_strings() {
             let argument: String = "foo".to_string();
             let StdoutUntrimmed(output) = cmd!(
-                executable_path("cradle_test_helper").to_str().unwrap(),
+                executable_path("cradle_test_helper"),
                 "reverse",
                 Stdin(argument)
             );


### PR DESCRIPTION
Removes some conversions which are unnecessary, now that cradle is more liberal in what it accepts as arguments.