### PR TITLE
Allow writing arbitrary byte sequences to stdin

### DIFF
--- a/justfile
+++ b/justfile
@@ -13,8 +13,8 @@ test-lib-fast +pattern="":
 context-integration-tests: build
   cargo run --features "test_executables" --bin context_integration_tests
 
-doc:
-  cargo doc --all
+doc +args="":
+  cargo doc --all {{args}}
 
 clippy:
   cargo clippy --all-targets --all-features

--- a/src/cmd_argument.rs
+++ b/src/cmd_argument.rs
@@ -276,11 +276,12 @@ impl CmdArgument for &Path {
 }
 
 /// See the [`CmdArgument`] implementation for [`Stdin`] below.
-pub struct Stdin<T: Into<String>>(pub T);
+pub struct Stdin<T: AsRef<[u8]>>(pub T);
 
-/// Writes the given [`&str`] to the child's standard input.
-/// If `Stdin` is used multiple times,
-/// all given strings will be written to the child's standard input in order.
+/// Writes the given byte slice to the child's standard input.
+///
+/// If `Stdin` is used multiple times, all given bytes slices will be written
+/// to the child's standard input in order.
 ///
 /// ```
 /// use cradle::*;
@@ -293,10 +294,10 @@ pub struct Stdin<T: Into<String>>(pub T);
 /// ```
 impl<T> CmdArgument for Stdin<T>
 where
-    T: Into<String>,
+    T: AsRef<[u8]>,
 {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
-        Arc::make_mut(&mut config.stdin).push(self.0.into());
+        Arc::make_mut(&mut config.stdin).extend_from_slice(self.0.as_ref());
     }
 }

--- a/src/collected_output.rs
+++ b/src/collected_output.rs
@@ -25,9 +25,7 @@ impl Waiter {
     {
         let config_stdin = config.stdin.clone();
         let stdin_join_handle = thread::spawn(move || -> io::Result<()> {
-            for stdin_snippet in config_stdin.iter() {
-                write!(child_stdin, "{}", stdin_snippet)?;
-            }
+            child_stdin.write_all(&config_stdin)?;
             Ok(())
         });
         let mut context_clone = context.clone();

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ pub struct Config {
     pub(crate) arguments: Vec<OsString>,
     pub(crate) log_command: bool,
     pub(crate) working_directory: Option<PathBuf>,
-    pub(crate) stdin: Arc<Vec<String>>,
+    pub(crate) stdin: Arc<Vec<u8>>,
     pub(crate) relay_stdout: bool,
     pub(crate) relay_stderr: bool,
     pub(crate) error_on_non_zero_exit_code: bool,

--- a/src/input.rs
+++ b/src/input.rs
@@ -313,9 +313,6 @@ pub struct Stdin<T: AsRef<[u8]>>(pub T);
 
 /// Writes the given byte slice to the child's standard input.
 ///
-/// If `Stdin` is used multiple times, all given bytes slices will be written
-/// to the child's standard input in order.
-///
 /// ```
 /// use cradle::*;
 ///
@@ -325,6 +322,9 @@ pub struct Stdin<T: AsRef<[u8]>>(pub T);
 /// assert_eq!(output, "bar\nfoo\n");
 /// # }
 /// ```
+///
+/// If `Stdin` is used multiple times, all given bytes slices will be written
+/// to the child's standard input in order.
 impl<T> Input for Stdin<T>
 where
     T: AsRef<[u8]>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1318,6 +1318,16 @@ mod tests {
         }
 
         #[test]
+        fn allows_passing_in_u8_slices_as_stdin() {
+            let StdoutUntrimmed(output) = cmd!(
+                executable_path("cradle_test_helper"),
+                "reverse",
+                Stdin(&[0, 1, 2])
+            );
+            assert_eq!(output, "\x02\x01\x00");
+        }
+
+        #[test]
         #[cfg(unix)]
         fn stdin_is_closed_by_default() {
             let StdoutTrimmed(output) = cmd!(


### PR DESCRIPTION
This changes `Stdin` to accept anything that implements `AsRef<[u8]`>`, which includes `String`, `&str`, `Vec<u8>`, `&[u8]`, and probably other things.

It uses a single `Vec<u8>` and issues a single write call, so it should be very slightly faster.