### PR TITLE
Parallelize tests and implement CmdArgument for TempDir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 /target/
 Cargo.lock
-/foo
-/filename with spaces

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,4 +44,5 @@ path = "src/context_integration_tests.rs"
 required-features = ["test_executables"]
 
 [features]
+tempdir = ["tempfile"]
 test_executables = ["gag", "executable-path", "nix"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ homepage = "https://github.com/soenkehahn/cradle"
 [dependencies]
 rustversion = "1.0.4"
 
+[dependencies.tempfile]
+version = "3.2.0"
+optional = true
+
 [dev-dependencies]
 executable-path = "1.0.0"
 pretty_assertions = "0.7.2"

--- a/justfile
+++ b/justfile
@@ -4,11 +4,10 @@ build:
   cargo build --all-targets --all-features
 
 test +pattern="": build
-  cargo test --all -- --test-threads=1 {{ pattern }}
-  rm -f 'filename with spaces' foo
+  cargo test --all -- {{ pattern }}
 
 test-lib-fast +pattern="":
-  cargo test --lib -- --test-threads=1 {{ pattern }}
+  cargo test --lib -- {{ pattern }}
 
 context-integration-tests: build
   cargo run --features "test_executables" --bin context_integration_tests

--- a/src/cmd_argument.rs
+++ b/src/cmd_argument.rs
@@ -305,7 +305,7 @@ where
 
 /// Argument of type [`TempDir`] configure the child to run
 /// with the current directory set to the tempdir.
-#[cfg(any(test, feature = "tempfile"))]
+#[cfg(any(test, feature = "tempdir"))]
 impl CmdArgument for &tempfile::TempDir {
     fn prepare_config(self, config: &mut Config) {
         CurrentDir(self.path()).prepare_config(config);

--- a/src/cmd_argument.rs
+++ b/src/cmd_argument.rs
@@ -263,7 +263,9 @@ impl CmdArgument for PathBuf {
 /// use cradle::*;
 /// use std::path::Path;
 ///
-/// let file: &Path = Path::new("./foo");
+/// let tempdir = tempfile::tempdir().unwrap();
+///
+/// let file: &Path = &tempdir.path().join("foo");
 /// cmd_unit!("touch", file);
 /// ```
 ///
@@ -298,5 +300,14 @@ where
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
         Arc::make_mut(&mut config.stdin).push(self.0.into());
+    }
+}
+
+/// Argument of type [`TempDir`] configure the child to run
+/// with the current directory set to the tempdir.
+#[cfg(any(test, feature = "tempfile"))]
+impl CmdArgument for &tempfile::TempDir {
+    fn prepare_config(self, config: &mut Config) {
+        CurrentDir(self.path()).prepare_config(config);
     }
 }


### PR DESCRIPTION
I did this because I thought the tests were slow because of `--test-threads=1`, but it turns out it's because [doctests are just inherently slow](https://github.com/rust-lang/cargo/issues/2944), so this doesn't actually improve the speed.

It does allow tests to be run with `cargo test` (at least if the test helper binaries are built), which is nice.

I also changed it to avoid creating tempfiles in the project root, and removed the corresponding entries in `.gitignore`.

To do this, I added a `CmdArgument` for `TempDir`, which I think is super useful, so I made it an optional feature.

You can enable the `tepdir` feature to enable the `CmdArgument` for `TempDir`, which enables the optional dependency on `tempfile`.