### PR TITLE
Allow trailing commas in `cmd!` invocations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1372,11 +1372,15 @@ mod tests {
         #[test]
         fn trailing_comma_is_accepted_after_normal_argument() {
             cmd_unit!("echo", "foo",);
+            let () = cmd!("echo", "foo",);
+            let _result: Result<(), Error> = cmd_result!("echo", "foo",);
         }
 
         #[test]
         fn trailing_comma_is_accepted_after_split_argument() {
             cmd_unit!("echo", %"foo",);
+            let () = cmd!("echo", %"foo",);
+            let _result: Result<(), Error> = cmd_result!("echo", %"foo",);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1372,14 +1372,14 @@ mod tests {
         #[test]
         fn trailing_comma_is_accepted_after_normal_argument() {
             cmd_unit!("echo", "foo",);
-            let () = cmd!("echo", "foo",);
+            let StdoutUntrimmed(_) = cmd!("echo", "foo",);
             let _result: Result<(), Error> = cmd_result!("echo", "foo",);
         }
 
         #[test]
         fn trailing_comma_is_accepted_after_split_argument() {
             cmd_unit!("echo", %"foo",);
-            let () = cmd!("echo", %"foo",);
+            let StdoutUntrimmed(_) = cmd!("echo", %"foo",);
             let _result: Result<(), Error> = cmd_result!("echo", %"foo",);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,12 @@ macro_rules! cmd_result_with_context {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! prepare_config {
+    (config: $config:ident, args: % $head:expr $(,)?) => {
+        $crate::CmdArgument::prepare_config($crate::Split($head), &mut $config);
+    };
+    (config: $config:ident, args: $head:expr $(,)?) => {
+        $crate::CmdArgument::prepare_config($head, &mut $config);
+    };
     (config: $config:ident, args: % $head:expr, $($tail:tt)*) => {
         $crate::CmdArgument::prepare_config($crate::Split($head), &mut $config);
         $crate::prepare_config!(config: $config, args: $($tail)*);
@@ -241,12 +247,6 @@ macro_rules! prepare_config {
     (config: $config:ident, args: $head:expr, $($tail:tt)*) => {
         $crate::CmdArgument::prepare_config($head, &mut $config);
         $crate::prepare_config!(config: $config, args: $($tail)*);
-    };
-    (config: $config:ident, args: % $head:expr) => {
-        $crate::CmdArgument::prepare_config($crate::Split($head), &mut $config);
-    };
-    (config: $config:ident, args: $head:expr) => {
-        $crate::CmdArgument::prepare_config($head, &mut $config);
     };
 }
 
@@ -1363,6 +1363,20 @@ mod tests {
                 Stdin(argument)
             );
             assert_eq!(output, "oof");
+        }
+    }
+
+    mod invocation_syntax {
+        use super::*;
+
+        #[test]
+        fn trailing_comma_is_accepted_after_normal_argument() {
+            cmd_unit!("echo", "foo",);
+        }
+
+        #[test]
+        fn trailing_comma_is_accepted_after_split_argument() {
+            cmd_unit!("echo", %"foo",);
         }
     }
 }


### PR DESCRIPTION
To make this work, I added a `$(,)?` to the end of the two base cases, and made them first, so they match in the case you get to the end and there's still a trailing comma.