### PR TITLE
Rename Input and Output and their methods

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -8,7 +8,7 @@ use std::{
 /// All types that are possible arguments to [`cmd!`] have to implement this trait.
 pub trait Input {
     #[doc(hidden)]
-    fn prepare_config(self, config: &mut Config);
+    fn configure(self, config: &mut Config);
 }
 
 /// Blanket implementation for `&_`.
@@ -17,8 +17,8 @@ where
     T: Input + Clone,
 {
     #[doc(hidden)]
-    fn prepare_config(self, config: &mut Config) {
-        self.clone().prepare_config(config);
+    fn configure(self, config: &mut Config) {
+        self.clone().configure(config);
     }
 }
 
@@ -32,7 +32,7 @@ where
 /// ```
 impl Input for OsString {
     #[doc(hidden)]
-    fn prepare_config(self, config: &mut Config) {
+    fn configure(self, config: &mut Config) {
         config.arguments.push(self);
     }
 }
@@ -49,8 +49,8 @@ impl Input for OsString {
 /// [`&OsStr`]: std::ffi::OsStr
 impl Input for &OsStr {
     #[doc(hidden)]
-    fn prepare_config(self, config: &mut Config) {
-        self.to_os_string().prepare_config(config);
+    fn configure(self, config: &mut Config) {
+        self.to_os_string().configure(config);
     }
 }
 
@@ -58,8 +58,8 @@ impl Input for &OsStr {
 /// as arguments.
 impl Input for &str {
     #[doc(hidden)]
-    fn prepare_config(self, config: &mut Config) {
-        OsStr::new(self).prepare_config(config);
+    fn configure(self, config: &mut Config) {
+        OsStr::new(self).configure(config);
     }
 }
 
@@ -67,8 +67,8 @@ impl Input for &str {
 /// as arguments.
 impl Input for String {
     #[doc(hidden)]
-    fn prepare_config(self, config: &mut Config) {
-        OsString::from(self).prepare_config(config);
+    fn configure(self, config: &mut Config) {
+        OsString::from(self).configure(config);
     }
 }
 
@@ -101,9 +101,9 @@ pub struct Split<T: AsRef<str>>(pub T);
 /// [`split_whitespace`]: str::split_whitespace
 impl<T: AsRef<str>> Input for Split<T> {
     #[doc(hidden)]
-    fn prepare_config(self, config: &mut Config) {
+    fn configure(self, config: &mut Config) {
         for argument in self.0.as_ref().split_whitespace() {
-            argument.prepare_config(config);
+            argument.configure(config);
         }
     }
 }
@@ -122,9 +122,9 @@ impl<T: AsRef<str>> Input for Split<T> {
 /// [`split`]: str::split
 impl<'a> Input for std::str::Split<'a, char> {
     #[doc(hidden)]
-    fn prepare_config(self, config: &mut Config) {
+    fn configure(self, config: &mut Config) {
         for word in self {
-            word.prepare_config(config);
+            word.configure(config);
         }
     }
 }
@@ -141,9 +141,9 @@ impl<'a> Input for std::str::Split<'a, char> {
 /// [`split_whitespace`]: str::split_whitespace
 impl<'a> Input for std::str::SplitWhitespace<'a> {
     #[doc(hidden)]
-    fn prepare_config(self, config: &mut Config) {
+    fn configure(self, config: &mut Config) {
         for word in self {
-            word.prepare_config(config);
+            word.configure(config);
         }
     }
 }
@@ -160,9 +160,9 @@ impl<'a> Input for std::str::SplitWhitespace<'a> {
 /// [`split_ascii_whitespace`]: str::split_ascii_whitespace
 impl<'a> Input for std::str::SplitAsciiWhitespace<'a> {
     #[doc(hidden)]
-    fn prepare_config(self, config: &mut Config) {
+    fn configure(self, config: &mut Config) {
         for word in self {
-            word.prepare_config(config);
+            word.configure(config);
         }
     }
 }
@@ -181,9 +181,9 @@ where
     T: Input,
 {
     #[doc(hidden)]
-    fn prepare_config(self, config: &mut Config) {
+    fn configure(self, config: &mut Config) {
         for t in self.into_iter() {
-            t.prepare_config(config);
+            t.configure(config);
         }
     }
 }
@@ -205,9 +205,9 @@ where
     T: Input,
 {
     #[doc(hidden)]
-    fn prepare_config(self, config: &mut Config) {
+    fn configure(self, config: &mut Config) {
         for t in std::array::IntoIter::new(self) {
-            t.prepare_config(config);
+            t.configure(config);
         }
     }
 }
@@ -219,8 +219,8 @@ where
     T: Input + Clone,
 {
     #[doc(hidden)]
-    fn prepare_config(self, config: &mut Config) {
-        self.to_vec().prepare_config(config);
+    fn configure(self, config: &mut Config) {
+        self.to_vec().configure(config);
     }
 }
 
@@ -240,7 +240,7 @@ pub struct LogCommand;
 /// ```
 impl Input for LogCommand {
     #[doc(hidden)]
-    fn prepare_config(self, config: &mut Config) {
+    fn configure(self, config: &mut Config) {
         config.log_command = true;
     }
 }
@@ -267,7 +267,7 @@ where
     T: AsRef<Path>,
 {
     #[doc(hidden)]
-    fn prepare_config(self, config: &mut Config) {
+    fn configure(self, config: &mut Config) {
         config.working_directory = Some(self.0.as_ref().to_owned());
     }
 }
@@ -284,8 +284,8 @@ where
 /// ```
 impl Input for PathBuf {
     #[doc(hidden)]
-    fn prepare_config(self, config: &mut Config) {
-        self.into_os_string().prepare_config(config);
+    fn configure(self, config: &mut Config) {
+        self.into_os_string().configure(config);
     }
 }
 
@@ -303,8 +303,8 @@ impl Input for PathBuf {
 /// [`&Path`]: std::path::Path
 impl Input for &Path {
     #[doc(hidden)]
-    fn prepare_config(self, config: &mut Config) {
-        self.as_os_str().to_os_string().prepare_config(config);
+    fn configure(self, config: &mut Config) {
+        self.as_os_str().to_os_string().configure(config);
     }
 }
 
@@ -329,7 +329,7 @@ where
     T: Into<String>,
 {
     #[doc(hidden)]
-    fn prepare_config(self, config: &mut Config) {
+    fn configure(self, config: &mut Config) {
         Arc::make_mut(&mut config.stdin).push(self.0.into());
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -6,15 +6,15 @@ use std::{
 };
 
 /// All types that are possible arguments to [`cmd!`] have to implement this trait.
-pub trait CmdInput {
+pub trait Input {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config);
 }
 
 /// Blanket implementation for `&_`.
-impl<T> CmdInput for &T
+impl<T> Input for &T
 where
-    T: CmdInput + Clone,
+    T: Input + Clone,
 {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
@@ -30,7 +30,7 @@ where
 ///
 /// cmd_unit!("ls", std::env::var_os("HOME").unwrap());
 /// ```
-impl CmdInput for OsString {
+impl Input for OsString {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
         config.arguments.push(self);
@@ -47,7 +47,7 @@ impl CmdInput for OsString {
 /// ```
 ///
 /// [`&OsStr`]: std::ffi::OsStr
-impl CmdInput for &OsStr {
+impl Input for &OsStr {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
         self.to_os_string().prepare_config(config);
@@ -56,7 +56,7 @@ impl CmdInput for &OsStr {
 
 /// Arguments of type [`&str`] are passed to the child process
 /// as arguments.
-impl CmdInput for &str {
+impl Input for &str {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
         OsStr::new(self).prepare_config(config);
@@ -65,14 +65,14 @@ impl CmdInput for &str {
 
 /// Arguments of type [`String`] are passed to the child process
 /// as arguments.
-impl CmdInput for String {
+impl Input for String {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
         OsString::from(self).prepare_config(config);
     }
 }
 
-/// See the [`CmdInput`] implementation for [`Split`] below.
+/// See the [`Input`] implementation for [`Split`] below.
 pub struct Split<T: AsRef<str>>(pub T);
 
 /// Splits the contained string by whitespace (using [`split_whitespace`])
@@ -99,7 +99,7 @@ pub struct Split<T: AsRef<str>>(pub T);
 /// ```
 ///
 /// [`split_whitespace`]: str::split_whitespace
-impl<T: AsRef<str>> CmdInput for Split<T> {
+impl<T: AsRef<str>> Input for Split<T> {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
         for argument in self.0.as_ref().split_whitespace() {
@@ -120,7 +120,7 @@ impl<T: AsRef<str>> CmdInput for Split<T> {
 /// Arguments to [`split`] must be of type [`char`].
 ///
 /// [`split`]: str::split
-impl<'a> CmdInput for std::str::Split<'a, char> {
+impl<'a> Input for std::str::Split<'a, char> {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
         for word in self {
@@ -139,7 +139,7 @@ impl<'a> CmdInput for std::str::Split<'a, char> {
 /// ```
 ///
 /// [`split_whitespace`]: str::split_whitespace
-impl<'a> CmdInput for std::str::SplitWhitespace<'a> {
+impl<'a> Input for std::str::SplitWhitespace<'a> {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
         for word in self {
@@ -158,7 +158,7 @@ impl<'a> CmdInput for std::str::SplitWhitespace<'a> {
 /// ```
 ///
 /// [`split_ascii_whitespace`]: str::split_ascii_whitespace
-impl<'a> CmdInput for std::str::SplitAsciiWhitespace<'a> {
+impl<'a> Input for std::str::SplitAsciiWhitespace<'a> {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
         for word in self {
@@ -176,9 +176,9 @@ impl<'a> CmdInput for std::str::SplitAsciiWhitespace<'a> {
 /// let StdoutTrimmed(output) = cmd!(vec!["echo", "foo"]);
 /// assert_eq!(output, "foo");
 /// ```
-impl<T> CmdInput for Vec<T>
+impl<T> Input for Vec<T>
 where
-    T: CmdInput,
+    T: Input,
 {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
@@ -200,9 +200,9 @@ where
 ///
 /// Only works on rust version `1.51` and up.
 #[rustversion::since(1.51)]
-impl<T, const N: usize> CmdInput for [T; N]
+impl<T, const N: usize> Input for [T; N]
 where
-    T: CmdInput,
+    T: Input,
 {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
@@ -214,9 +214,9 @@ where
 
 /// Similar to the implementation for [`Vec<T>`].
 /// All elements of the slice will be used as arguments.
-impl<T> CmdInput for &[T]
+impl<T> Input for &[T]
 where
-    T: CmdInput + Clone,
+    T: Input + Clone,
 {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
@@ -224,7 +224,7 @@ where
     }
 }
 
-/// See the [`CmdInput`] implementation for [`LogCommand`] below.
+/// See the [`Input`] implementation for [`LogCommand`] below.
 #[derive(Clone, Debug)]
 pub struct LogCommand;
 
@@ -238,14 +238,14 @@ pub struct LogCommand;
 /// cmd_unit!(LogCommand, %"echo foo");
 /// // writes '+ echo foo' to stderr
 /// ```
-impl CmdInput for LogCommand {
+impl Input for LogCommand {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
         config.log_command = true;
     }
 }
 
-/// See the [`CmdInput`] implementation for [`CurrentDir`] below.
+/// See the [`Input`] implementation for [`CurrentDir`] below.
 pub struct CurrentDir<T: AsRef<Path>>(pub T);
 
 /// By default child processes inherit the current directory from their
@@ -262,7 +262,7 @@ pub struct CurrentDir<T: AsRef<Path>>(pub T);
 /// ```
 ///
 /// Paths that are relative to the parent's current directory are allowed.
-impl<T> CmdInput for CurrentDir<T>
+impl<T> Input for CurrentDir<T>
 where
     T: AsRef<Path>,
 {
@@ -282,7 +282,7 @@ where
 /// let current_dir: PathBuf = std::env::current_dir().unwrap();
 /// cmd_unit!("ls", current_dir);
 /// ```
-impl CmdInput for PathBuf {
+impl Input for PathBuf {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
         self.into_os_string().prepare_config(config);
@@ -301,14 +301,14 @@ impl CmdInput for PathBuf {
 /// ```
 ///
 /// [`&Path`]: std::path::Path
-impl CmdInput for &Path {
+impl Input for &Path {
     #[doc(hidden)]
     fn prepare_config(self, config: &mut Config) {
         self.as_os_str().to_os_string().prepare_config(config);
     }
 }
 
-/// See the [`CmdInput`] implementation for [`Stdin`] below.
+/// See the [`Input`] implementation for [`Stdin`] below.
 pub struct Stdin<T: Into<String>>(pub T);
 
 /// Writes the given [`&str`] to the child's standard input.
@@ -324,7 +324,7 @@ pub struct Stdin<T: Into<String>>(pub T);
 /// assert_eq!(output, "bar\nfoo\n");
 /// # }
 /// ```
-impl<T> CmdInput for Stdin<T>
+impl<T> Input for Stdin<T>
 where
     T: Into<String>,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! # Arguments
 //!
 //! You can pass in multiple arguments (of different types) to [`cmd!`]
-//! to specify arguments, as long as they implement the [`CmdInput`]
+//! to specify arguments, as long as they implement the [`Input`]
 //! trait:
 //!
 //! ```
@@ -25,7 +25,7 @@
 //! assert_eq!(stdout, "foo bar");
 //! ```
 //!
-//! For all possible inputs to [`cmd!`], see the documentation of [`CmdInput`].
+//! For all possible inputs to [`cmd!`], see the documentation of [`Input`].
 //!
 //! ## Whitespace Splitting
 //!
@@ -173,18 +173,18 @@
 //! [`cmd`](https://hackage.haskell.org/package/shake-0.19.4/docs/Development-Shake.html#v:cmd)
 //! function.
 
-mod cmd_input;
 mod cmd_output;
 mod collected_output;
 mod config;
 mod context;
 mod error;
+mod input;
 
 use crate::collected_output::Waiter;
 pub use crate::{
-    cmd_input::{CmdInput, CurrentDir, LogCommand, Split, Stdin},
     cmd_output::{CmdOutput, Exit, Stderr, StdoutTrimmed, StdoutUntrimmed},
     error::{panic_on_error, Error},
+    input::{CurrentDir, Input, LogCommand, Split, Stdin},
 };
 #[doc(hidden)]
 pub use crate::{config::Config, context::Context};
@@ -235,17 +235,17 @@ macro_rules! cmd_result_with_context {
 #[macro_export]
 macro_rules! prepare_config {
     (config: $config:ident, args: % $head:expr $(,)?) => {
-        $crate::CmdInput::prepare_config($crate::Split($head), &mut $config);
+        $crate::Input::prepare_config($crate::Split($head), &mut $config);
     };
     (config: $config:ident, args: $head:expr $(,)?) => {
-        $crate::CmdInput::prepare_config($head, &mut $config);
+        $crate::Input::prepare_config($head, &mut $config);
     };
     (config: $config:ident, args: % $head:expr, $($tail:tt)*) => {
-        $crate::CmdInput::prepare_config($crate::Split($head), &mut $config);
+        $crate::Input::prepare_config($crate::Split($head), &mut $config);
         $crate::prepare_config!(config: $config, args: $($tail)*);
     };
     (config: $config:ident, args: $head:expr, $($tail:tt)*) => {
-        $crate::CmdInput::prepare_config($head, &mut $config);
+        $crate::Input::prepare_config($head, &mut $config);
         $crate::prepare_config!(config: $config, args: $($tail)*);
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@
 //! # Output
 //!
 //! You can choose which return type you want [`cmd!`] to return,
-//! as long as the chosen return type implements [`CmdOutput`].
+//! as long as the chosen return type implements [`Output`].
 //! For example you can use e.g. [`StdoutTrimmed`] to collect what the
 //! child process writes to `stdout`,
 //! trimmed of leading and trailing whitespace:
@@ -101,7 +101,7 @@
 //! cmd_unit!(%"touch foo");
 //! ```
 //!
-//! See the implementations for [`CmdOutput`] for all the supported types.
+//! See the implementations for [`Output`] for all the supported types.
 //!
 //! # Error Handling
 //!
@@ -133,7 +133,7 @@
 //! You can also turn **all** panics into [`std::result::Result::Err`]s
 //! by using [`cmd_result!`]. This will return a value of type
 //! [`Result<T, cradle::Error>`], where
-//! `T` is any type that implements [`CmdOutput`].
+//! `T` is any type that implements [`Output`].
 //! Here's some examples:
 //!
 //! ```
@@ -173,21 +173,21 @@
 //! [`cmd`](https://hackage.haskell.org/package/shake-0.19.4/docs/Development-Shake.html#v:cmd)
 //! function.
 
-mod cmd_output;
 mod collected_output;
 mod config;
 mod context;
 mod error;
 mod input;
+mod output;
 
 use crate::collected_output::Waiter;
-pub use crate::{
-    cmd_output::{CmdOutput, Exit, Stderr, StdoutTrimmed, StdoutUntrimmed},
-    error::{panic_on_error, Error},
-    input::{CurrentDir, Input, LogCommand, Split, Stdin},
-};
 #[doc(hidden)]
 pub use crate::{config::Config, context::Context};
+pub use crate::{
+    error::{panic_on_error, Error},
+    input::{CurrentDir, Input, LogCommand, Split, Stdin},
+    output::{Exit, Output, Stderr, StdoutTrimmed, StdoutUntrimmed},
+};
 use std::{
     ffi::OsString,
     io::Write,
@@ -212,7 +212,7 @@ macro_rules! cmd_unit {
 }
 
 /// Like [`cmd!`], but fixes the return type to [`Result<T, Error>`],
-/// where `T` is any type that implements [`CmdOutput`].
+/// where `T` is any type that implements [`Output`].
 #[macro_export]
 macro_rules! cmd_result {
     ($($args:tt)*) => {{
@@ -258,9 +258,9 @@ pub fn run_cmd<Stdout, Stderr, T>(
 where
     Stdout: Write + Clone + Send + 'static,
     Stderr: Write + Clone + Send + 'static,
-    T: CmdOutput,
+    T: Output,
 {
-    <T as CmdOutput>::prepare_config(&mut config);
+    <T as Output>::prepare_config(&mut config);
     let result = run_cmd_safe(context, &config);
     T::from_run_result(&config, result)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,27 +226,27 @@ macro_rules! cmd_result {
 macro_rules! cmd_result_with_context {
     ($context:expr, $($args:tt)*) => {{
         let mut config = $crate::Config::default();
-        $crate::prepare_config!(config: config, args: $($args)*);
+        $crate::configure!(config: config, args: $($args)*);
         $crate::run_cmd($context, config)
     }}
 }
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! prepare_config {
+macro_rules! configure {
     (config: $config:ident, args: % $head:expr $(,)?) => {
-        $crate::Input::prepare_config($crate::Split($head), &mut $config);
+        $crate::Input::configure($crate::Split($head), &mut $config);
     };
     (config: $config:ident, args: $head:expr $(,)?) => {
-        $crate::Input::prepare_config($head, &mut $config);
+        $crate::Input::configure($head, &mut $config);
     };
     (config: $config:ident, args: % $head:expr, $($tail:tt)*) => {
-        $crate::Input::prepare_config($crate::Split($head), &mut $config);
-        $crate::prepare_config!(config: $config, args: $($tail)*);
+        $crate::Input::configure($crate::Split($head), &mut $config);
+        $crate::configure!(config: $config, args: $($tail)*);
     };
     (config: $config:ident, args: $head:expr, $($tail:tt)*) => {
-        $crate::Input::prepare_config($head, &mut $config);
-        $crate::prepare_config!(config: $config, args: $($tail)*);
+        $crate::Input::configure($head, &mut $config);
+        $crate::configure!(config: $config, args: $($tail)*);
     };
 }
 
@@ -260,7 +260,7 @@ where
     Stderr: Write + Clone + Send + 'static,
     T: Output,
 {
-    <T as Output>::prepare_config(&mut config);
+    <T as Output>::configure(&mut config);
     let result = run_cmd_safe(context, &config);
     T::from_run_result(&config, result)
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -20,7 +20,7 @@ use std::{process::ExitStatus, sync::Arc};
 /// ```
 pub trait Output: Sized {
     #[doc(hidden)]
-    fn prepare_config(config: &mut Config);
+    fn configure(config: &mut Config);
 
     #[doc(hidden)]
     fn from_run_result(config: &Config, result: Result<RunResult, Error>) -> Result<Self, Error>;
@@ -29,7 +29,7 @@ pub trait Output: Sized {
 /// Use this when you don't need any result from the child process.
 impl Output for () {
     #[doc(hidden)]
-    fn prepare_config(_config: &mut Config) {}
+    fn configure(_config: &mut Config) {}
 
     #[doc(hidden)]
     fn from_run_result(_config: &Config, result: Result<RunResult, Error>) -> Result<Self, Error> {
@@ -63,8 +63,8 @@ pub struct StdoutTrimmed(pub String);
 /// # }
 /// ```
 impl Output for StdoutTrimmed {
-    fn prepare_config(config: &mut Config) {
-        StdoutUntrimmed::prepare_config(config);
+    fn configure(config: &mut Config) {
+        StdoutUntrimmed::configure(config);
     }
 
     fn from_run_result(config: &Config, result: Result<RunResult, Error>) -> Result<Self, Error> {
@@ -87,7 +87,7 @@ pub struct StdoutUntrimmed(pub String);
 /// ```
 impl Output for StdoutUntrimmed {
     #[doc(hidden)]
-    fn prepare_config(config: &mut Config) {
+    fn configure(config: &mut Config) {
         config.relay_stdout = false;
     }
 
@@ -110,8 +110,8 @@ macro_rules! tuple_impl {
             $($generics: Output,)+
         {
             #[doc(hidden)]
-            fn prepare_config(config: &mut Config) {
-                $($generics::prepare_config(config);)+
+            fn configure(config: &mut Config) {
+                $($generics::configure(config);)+
             }
 
             #[doc(hidden)]
@@ -159,7 +159,7 @@ pub struct Exit(pub ExitStatus);
 /// the module documentation.
 impl Output for Exit {
     #[doc(hidden)]
-    fn prepare_config(config: &mut Config) {
+    fn configure(config: &mut Config) {
         config.error_on_non_zero_exit_code = false;
     }
 
@@ -192,7 +192,7 @@ pub struct Stderr(pub String);
 /// is used, this is switched off.
 impl Output for Stderr {
     #[doc(hidden)]
-    fn prepare_config(config: &mut Config) {
+    fn configure(config: &mut Config) {
         config.relay_stderr = false;
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -5,8 +5,8 @@ use std::{process::ExitStatus, sync::Arc};
 /// For documentation about what these return types do, see the
 /// individual implementations below.
 ///
-/// Except for tuples: All [`CmdOutput`] implementations for tuples serve
-/// the same purpose: combining multiple types that implement [`CmdOutput`]
+/// Except for tuples: All [`Output`] implementations for tuples serve
+/// the same purpose: combining multiple types that implement [`Output`]
 /// to retrieve more information from a child process. The following code
 /// for example retrieves what's written to `stdout` **and** the
 /// [`ExitStatus`]:
@@ -18,7 +18,7 @@ use std::{process::ExitStatus, sync::Arc};
 /// assert_eq!(stdout, "foo\n");
 /// assert!(status.success());
 /// ```
-pub trait CmdOutput: Sized {
+pub trait Output: Sized {
     #[doc(hidden)]
     fn prepare_config(config: &mut Config);
 
@@ -27,7 +27,7 @@ pub trait CmdOutput: Sized {
 }
 
 /// Use this when you don't need any result from the child process.
-impl CmdOutput for () {
+impl Output for () {
     #[doc(hidden)]
     fn prepare_config(_config: &mut Config) {}
 
@@ -38,7 +38,7 @@ impl CmdOutput for () {
     }
 }
 
-/// See the [`CmdOutput`] implementation for [`StdoutTrimmed`] below.
+/// See the [`Output`] implementation for [`StdoutTrimmed`] below.
 #[derive(Debug, PartialEq, Clone)]
 pub struct StdoutTrimmed(pub String);
 
@@ -62,7 +62,7 @@ pub struct StdoutTrimmed(pub String);
 /// assert!(Path::new(&output).exists());
 /// # }
 /// ```
-impl CmdOutput for StdoutTrimmed {
+impl Output for StdoutTrimmed {
     fn prepare_config(config: &mut Config) {
         StdoutUntrimmed::prepare_config(config);
     }
@@ -73,7 +73,7 @@ impl CmdOutput for StdoutTrimmed {
     }
 }
 
-/// See the [`CmdOutput`] implementation for [`StdoutUntrimmed`] below.
+/// See the [`Output`] implementation for [`StdoutUntrimmed`] below.
 #[derive(Debug, PartialEq, Clone)]
 pub struct StdoutUntrimmed(pub String);
 
@@ -85,7 +85,7 @@ pub struct StdoutUntrimmed(pub String);
 /// let StdoutUntrimmed(output) = cmd!(%"echo foo");
 /// assert_eq!(output, "foo\n");
 /// ```
-impl CmdOutput for StdoutUntrimmed {
+impl Output for StdoutUntrimmed {
     #[doc(hidden)]
     fn prepare_config(config: &mut Config) {
         config.relay_stdout = false;
@@ -105,9 +105,9 @@ impl CmdOutput for StdoutUntrimmed {
 
 macro_rules! tuple_impl {
     ($($generics:ident,)+) => {
-        impl<$($generics),+> CmdOutput for ($($generics,)+)
+        impl<$($generics),+> Output for ($($generics,)+)
         where
-            $($generics: CmdOutput,)+
+            $($generics: Output,)+
         {
             #[doc(hidden)]
             fn prepare_config(config: &mut Config) {
@@ -128,7 +128,7 @@ tuple_impl!(A,);
 tuple_impl!(A, B,);
 tuple_impl!(A, B, C,);
 
-/// See the [`CmdOutput`] implementation for [`Exit`] below.
+/// See the [`Output`] implementation for [`Exit`] below.
 pub struct Exit(pub ExitStatus);
 
 /// Using [`Exit`] as the return type for [`cmd!`] allows to
@@ -157,7 +157,7 @@ pub struct Exit(pub ExitStatus);
 /// Also see the
 /// [section about error handling](index.html#error-handling) in
 /// the module documentation.
-impl CmdOutput for Exit {
+impl Output for Exit {
     #[doc(hidden)]
     fn prepare_config(config: &mut Config) {
         config.error_on_non_zero_exit_code = false;
@@ -169,7 +169,7 @@ impl CmdOutput for Exit {
     }
 }
 
-/// See the [`CmdOutput`] implementation for [`Stderr`] below.
+/// See the [`Output`] implementation for [`Stderr`] below.
 #[derive(Debug)]
 pub struct Stderr(pub String);
 
@@ -190,7 +190,7 @@ pub struct Stderr(pub String);
 /// By default, what is written to `stderr` by the child process
 /// is relayed to the parent's `stderr`. However, when [`Stderr`]
 /// is used, this is switched off.
-impl CmdOutput for Stderr {
+impl Output for Stderr {
     #[doc(hidden)]
     fn prepare_config(config: &mut Config) {
         config.relay_stderr = false;


### PR DESCRIPTION
- Rename CmdInput to Input
- Rename CmdOutput to Output
- Rename prepare_config to configure everywhere
