### PR TITLE
Add Cargo.toml to cache key

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
             ~/.cargo/git
             ~/.cargo/bin
             target
-          key: cargo-${{ env.CACHE_KEY }}-${{ runner.os }}-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-${{ env.CACHE_KEY }}-${{ runner.os }}-${{ matrix.rust }}-${{ hashFiles('Cargo.toml') }}
 
       - name: Install just
         run: |


### PR DESCRIPTION
Before I was trying to add hashes for `Cargo.lock` files, but those aren't checked into the repo, so that didn't work at all.