### PR TITLE
Remove unnecessary wrapping in Vec in tests

### DIFF
--- a/src/context_integration_tests.rs
+++ b/src/context_integration_tests.rs
@@ -28,7 +28,7 @@ fn main() {
             assert_eq!(
                 with_gag(BufferRedirect::stderr, || cmd!(
                     executable_path("cradle_test_helper").to_str().unwrap(),
-                    vec!["write to stderr"]
+                    "write to stderr"
                 )),
                 "foo\n"
             );

--- a/src/error.rs
+++ b/src/error.rs
@@ -89,7 +89,7 @@ mod tests {
     fn invalid_utf8_to_stdout_has_source() {
         let result: Result<StdoutUntrimmed, crate::Error> = cmd_result!(
             executable_path("cradle_test_helper").to_str().unwrap(),
-            vec!["invalid utf-8 stdout"]
+            "invalid utf-8 stdout"
         );
         assert!(result.unwrap_err().source().is_some());
     }
@@ -98,7 +98,7 @@ mod tests {
     fn invalid_utf8_to_stderr_has_source() {
         let result: Result<Stderr, crate::Error> = cmd_result!(
             executable_path("cradle_test_helper").to_str().unwrap(),
-            vec!["invalid utf-8 stderr"]
+            "invalid utf-8 stderr"
         );
         assert!(result.unwrap_err().source().is_some());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,7 +414,7 @@ mod tests {
             #[test]
             #[should_panic(expected = "exited with exit code: 42")]
             fn other_exit_codes() {
-                cmd_unit!(executable_path("cradle_test_helper"), vec!["exit code 42"]);
+                cmd_unit!(executable_path("cradle_test_helper"), "exit code 42");
             }
 
             #[test]
@@ -463,7 +463,7 @@ mod tests {
             fn invalid_utf8_stdout() {
                 let StdoutTrimmed(_) = cmd!(
                     executable_path("cradle_test_helper"),
-                    vec!["invalid utf-8 stdout"]
+                    "invalid utf-8 stdout"
                 );
             }
 
@@ -471,7 +471,7 @@ mod tests {
             fn invalid_utf8_to_stdout_is_allowed_when_not_captured() {
                 cmd_unit!(
                     executable_path("cradle_test_helper"),
-                    vec!["invalid utf-8 stdout"]
+                    "invalid utf-8 stdout"
                 );
             }
         }
@@ -535,7 +535,7 @@ mod tests {
             #[test]
             fn other_exit_codes() {
                 let result: Result<(), Error> =
-                    cmd_result!(executable_path("cradle_test_helper"), vec!["exit code 42"]);
+                    cmd_result!(executable_path("cradle_test_helper"), "exit code 42");
                 assert!(result
                     .unwrap_err()
                     .to_string()
@@ -566,7 +566,7 @@ mod tests {
             fn invalid_utf8_stdout() {
                 let test_helper = executable_path("cradle_test_helper");
                 let result: Result<StdoutTrimmed, Error> =
-                    cmd_result!(&test_helper, vec!["invalid utf-8 stdout"]);
+                    cmd_result!(&test_helper, "invalid utf-8 stdout");
                 assert_eq!(
                     result.unwrap_err().to_string(),
                     format!(
@@ -602,13 +602,6 @@ mod tests {
         let executable: &String = &"echo".to_string();
         let argument: &String = &"foo".to_string();
         let StdoutTrimmed(stdout) = cmd!(reference, executable, argument);
-        assert_eq!(stdout, "foo");
-    }
-
-    #[test]
-    fn allows_to_pass_in_arguments_as_a_vec_of_ref_str() {
-        let args: Vec<&str> = vec!["foo"];
-        let StdoutTrimmed(stdout) = cmd!("echo", args);
         assert_eq!(stdout, "foo");
     }
 
@@ -777,7 +770,7 @@ mod tests {
             let _: Result<(), Error> = cmd_result_with_context!(
                 context.clone(),
                 executable_path("cradle_test_helper"),
-                vec!["output foo and exit with 42"]
+                "output foo and exit with 42"
             );
             assert_eq!(context.stdout(), "foo\n");
         }
@@ -791,7 +784,7 @@ mod tests {
                     cmd_result_with_context_unit!(
                         context_clone,
                         executable_path("cradle_test_helper"),
-                        vec!["stream chunk then wait for file"]
+                        "stream chunk then wait for file"
                     )
                     .unwrap();
                 });
@@ -830,7 +823,7 @@ mod tests {
             cmd_result_with_context_unit!(
                 context.clone(),
                 executable_path("cradle_test_helper"),
-                vec!["write to stderr"]
+                "write to stderr"
             )
             .unwrap();
             assert_eq!(context.stderr(), "foo\n");
@@ -842,7 +835,7 @@ mod tests {
             let _: Result<(), Error> = cmd_result_with_context!(
                 context.clone(),
                 executable_path("cradle_test_helper"),
-                vec!["write to stderr and exit with 42"]
+                "write to stderr and exit with 42"
             );
             assert_eq!(context.stderr(), "foo\n");
         }
@@ -856,7 +849,7 @@ mod tests {
                     cmd_result_with_context_unit!(
                         context_clone,
                         executable_path("cradle_test_helper"),
-                        vec!["stream chunk to stderr then wait for file"]
+                        "stream chunk to stderr then wait for file"
                     )
                     .unwrap();
                 });
@@ -881,18 +874,14 @@ mod tests {
 
         #[test]
         fn capture_stderr() {
-            let Stderr(stderr) = cmd!(
-                executable_path("cradle_test_helper"),
-                vec!["write to stderr"]
-            );
+            let Stderr(stderr) = cmd!(executable_path("cradle_test_helper"), "write to stderr");
             assert_eq!(stderr, "foo\n");
         }
 
         #[test]
         fn assumes_stderr_is_utf_8() {
             let test_helper = executable_path("cradle_test_helper");
-            let result: Result<Stderr, Error> =
-                cmd_result!(&test_helper, vec!["invalid utf-8 stderr"]);
+            let result: Result<Stderr, Error> = cmd_result!(&test_helper, "invalid utf-8 stderr");
             assert_eq!(
                 result.unwrap_err().to_string(),
                 format!(
@@ -906,7 +895,7 @@ mod tests {
         fn does_allow_invalid_utf_8_to_stderr_when_not_capturing() {
             cmd_unit!(
                 executable_path("cradle_test_helper"),
-                vec!["invalid utf-8 stderr"]
+                "invalid utf-8 stderr"
             );
         }
 
@@ -916,7 +905,7 @@ mod tests {
             let Stderr(_) = cmd_result_with_context!(
                 context.clone(),
                 executable_path("cradle_test_helper"),
-                vec!["write to stderr"]
+                "write to stderr"
             )
             .unwrap();
             assert_eq!(context.stderr(), "");
@@ -943,8 +932,7 @@ mod tests {
         #[test]
         fn quotes_arguments_with_spaces() {
             let context = Context::test();
-            cmd_result_with_context_unit!(context.clone(), LogCommand, "echo", vec!["foo bar"])
-                .unwrap();
+            cmd_result_with_context_unit!(context.clone(), LogCommand, "echo", "foo bar").unwrap();
             assert_eq!(context.stderr(), "+ echo 'foo bar'\n");
         }
 
@@ -984,8 +972,7 @@ mod tests {
 
         #[test]
         fn forty_two() {
-            let Exit(exit_status) =
-                cmd!(executable_path("cradle_test_helper"), vec!["exit code 42"]);
+            let Exit(exit_status) = cmd!(executable_path("cradle_test_helper"), "exit code 42");
             assert!(!exit_status.success());
             assert_eq!(exit_status.code(), Some(42));
         }
@@ -1004,7 +991,7 @@ mod tests {
         fn two_tuple_1() {
             let (StdoutTrimmed(output), Exit(status)) = cmd!(
                 executable_path("cradle_test_helper"),
-                vec!["output foo and exit with 42"]
+                "output foo and exit with 42"
             );
             assert_eq!(output, "foo");
             assert_eq!(status.code(), Some(42));
@@ -1014,7 +1001,7 @@ mod tests {
         fn two_tuple_2() {
             let (Exit(status), StdoutTrimmed(output)) = cmd!(
                 executable_path("cradle_test_helper"),
-                vec!["output foo and exit with 42"]
+                "output foo and exit with 42"
             );
             assert_eq!(output, "foo");
             assert_eq!(status.code(), Some(42));
@@ -1046,7 +1033,7 @@ mod tests {
         fn capturing_stdout_on_errors() {
             let (StdoutTrimmed(output), Exit(status)) = cmd!(
                 executable_path("cradle_test_helper"),
-                vec!["output foo and exit with 42"]
+                "output foo and exit with 42"
             );
             assert!(!status.success());
             assert_eq!(output, "foo");
@@ -1056,7 +1043,7 @@ mod tests {
         fn capturing_stderr_on_errors() {
             let (Stderr(output), Exit(status)) = cmd!(
                 executable_path("cradle_test_helper"),
-                vec!["write to stderr and exit with 42"]
+                "write to stderr and exit with 42"
             );
             assert!(!status.success());
             assert_eq!(output, "foo\n");
@@ -1106,19 +1093,19 @@ mod tests {
 
             #[test]
             fn trims_leading_whitespace() {
-                let StdoutTrimmed(output) = cmd!(%"echo -n", vec![" foo"]);
+                let StdoutTrimmed(output) = cmd!(%"echo -n", " foo");
                 assert_eq!(output, "foo");
             }
 
             #[test]
             fn does_not_remove_whitespace_within_output() {
-                let StdoutTrimmed(output) = cmd!(%"echo -n", vec!["foo bar"]);
+                let StdoutTrimmed(output) = cmd!(%"echo -n", "foo bar");
                 assert_eq!(output, "foo bar");
             }
 
             #[test]
             fn does_not_modify_output_without_whitespace() {
-                let StdoutTrimmed(output) = cmd!(%"echo -n foo");
+                let StdoutTrimmed(output) = cmd!(%"echo -n", "foo");
                 assert_eq!(output, "foo");
             }
 
@@ -1142,7 +1129,7 @@ mod tests {
 
             #[test]
             fn does_not_trim_leading_whitespace() {
-                let StdoutUntrimmed(output) = cmd!(%"echo -n", vec![" foo"]);
+                let StdoutUntrimmed(output) = cmd!(%"echo -n", " foo");
                 assert_eq!(output, " foo");
             }
 


### PR DESCRIPTION
This used to be necessary in tests to avoid splitting on whitespace.
But `cradle` doesn't split strings by whitespace by default anymore.
