### PR TITLE
Tweak documentation for Output

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -1,23 +1,54 @@
 use crate::{Config, Error, RunResult};
 use std::{process::ExitStatus, sync::Arc};
 
-/// All possible return types of [`cmd!`] have to implement this trait.
-/// For documentation about what these return types do, see the
-/// individual implementations below.
-///
-/// Except for tuples: All [`Output`] implementations for tuples serve
-/// the same purpose: combining multiple types that implement [`Output`]
-/// to retrieve more information from a child process. The following code
-/// for example retrieves what's written to `stdout` **and** the
-/// [`ExitStatus`]:
+/// All possible return types of [`cmd!`], [`cmd_unit!`] or
+/// [`cmd_result!`] must implement this trait.
+/// This return-type polymorphism makes cradle very flexible.
+/// For example if you want to capture what a command writes
+/// to its `stdout` you can do that using [`StdoutUntrimmed`]:
 ///
 /// ```
 /// use cradle::*;
 ///
-/// let (StdoutUntrimmed(stdout), Exit(status)) = cmd!(%"echo foo");
-/// assert_eq!(stdout, "foo\n");
-/// assert!(status.success());
+/// let StdoutUntrimmed(output) = cmd!(%"echo foo");
+/// assert_eq!(output, "foo\n");
 /// ```
+///
+/// But if instead you want to capture the commands exit code,
+/// you can use [`Exit`]:
+///
+/// ```
+/// use cradle::*;
+///
+/// let Exit(status) = cmd!("false");
+/// assert_eq!(status.code(), Some(1));
+/// ```
+///
+/// For documentation on what all these possible return types do,
+/// see the documentation for the individual impls of [`Output`].
+/// Here's a non-exhaustive list of the more commonly used return-types to get you started:
+///
+/// - `()`: In case you don't want to capture anything. See also [`cmd_unit`].
+/// - [`StdoutUntrimmed`], [`StdoutTrimmed`] and [`Stderr`]: To capture `stdout` and `stderr`.
+/// - [`Exit`]: To capture the commands exit code.
+///
+/// Alse, [`Output`] is implemented for a number of tuples.
+/// You can use this to combine other return-types that implement [`Output`].
+/// The following code for example retrieves the [`ExitStatus`]
+/// **and** what's written to `stdout`:
+///
+/// ```
+/// use cradle::*;
+///
+/// let (Exit(status), StdoutUntrimmed(stdout)) = cmd!(%"echo foo");
+/// assert!(status.success());
+/// assert_eq!(stdout, "foo\n");
+/// ```
+///
+/// [`StdoutUntrimmed`]: trait.Output.html#impl-Output-3
+/// [`StdoutTrimmed`]: trait.Output.html#impl-Output-2
+/// [`Stderr`]: trait.Output.html#impl-Output-1
+/// [`Exit`]: trait.Output.html#impl-Output
 pub trait Output: Sized {
     #[doc(hidden)]
     fn configure(config: &mut Config);
@@ -63,10 +94,12 @@ pub struct StdoutTrimmed(pub String);
 /// # }
 /// ```
 impl Output for StdoutTrimmed {
+    #[doc(hidden)]
     fn configure(config: &mut Config) {
         StdoutUntrimmed::configure(config);
     }
 
+    #[doc(hidden)]
     fn from_run_result(config: &Config, result: Result<RunResult, Error>) -> Result<Self, Error> {
         let StdoutUntrimmed(stdout) = StdoutUntrimmed::from_run_result(config, result)?;
         Ok(StdoutTrimmed(stdout.trim().to_owned()))

--- a/src/output.rs
+++ b/src/output.rs
@@ -33,7 +33,7 @@ use std::{process::ExitStatus, sync::Arc};
 /// - [`Exit`]: To capture the command's [`ExitStatus`].
 ///
 /// Also, [`Output`] is implemented for tuples.
-/// You can use this to combine other return types that implement [`Output`].
+/// You can use this to combine multiple return types that implement [`Output`].
 /// The following code for example retrieves the [`ExitStatus`]
 /// **and** what's written to `stdout`:
 ///

--- a/src/output.rs
+++ b/src/output.rs
@@ -14,7 +14,7 @@ use std::{process::ExitStatus, sync::Arc};
 /// assert_eq!(output, "foo\n");
 /// ```
 ///
-/// But if instead you want to capture the commands [`ExitStatus`],
+/// But if instead you want to capture the command's [`ExitStatus`],
 /// you can use [`Exit`]:
 ///
 /// ```

--- a/src/output.rs
+++ b/src/output.rs
@@ -30,7 +30,7 @@ use std::{process::ExitStatus, sync::Arc};
 ///
 /// - `()`: In case you don't want to capture anything. See also [`cmd_unit`].
 /// - [`StdoutUntrimmed`], [`StdoutTrimmed`] and [`Stderr`]: To capture `stdout`, `stdout` trimmed of whitespace, and `stderr`.
-/// - [`Exit`]: To capture the commands [`ExitStatus`].
+/// - [`Exit`]: To capture the command's [`ExitStatus`].
 ///
 /// Alse, [`Output`] is implemented for a number of tuples of different lengths.
 /// You can use this to combine other return types that implement [`Output`].

--- a/src/output.rs
+++ b/src/output.rs
@@ -32,7 +32,7 @@ use std::{process::ExitStatus, sync::Arc};
 /// - [`StdoutUntrimmed`], [`StdoutTrimmed`] and [`Stderr`]: To capture `stdout`, `stdout` trimmed of whitespace, and `stderr`.
 /// - [`Exit`]: To capture the command's [`ExitStatus`].
 ///
-/// Alse, [`Output`] is implemented for a number of tuples of different lengths.
+/// Also, [`Output`] is implemented for tuples.
 /// You can use this to combine other return types that implement [`Output`].
 /// The following code for example retrieves the [`ExitStatus`]
 /// **and** what's written to `stdout`:

--- a/src/output.rs
+++ b/src/output.rs
@@ -24,7 +24,7 @@ use std::{process::ExitStatus, sync::Arc};
 /// assert_eq!(status.code(), Some(1));
 /// ```
 ///
-/// For documentation on what all these possible return types do,
+/// For documentation on what all the possible return types do,
 /// see the documentation for the individual impls of [`Output`].
 /// Here's a non-exhaustive list of the more commonly used return-types to get you started:
 ///
@@ -32,7 +32,7 @@ use std::{process::ExitStatus, sync::Arc};
 /// - [`StdoutUntrimmed`], [`StdoutTrimmed`] and [`Stderr`]: To capture `stdout` and `stderr`.
 /// - [`Exit`]: To capture the commands exit code.
 ///
-/// Alse, [`Output`] is implemented for a number of tuples.
+/// Alse, [`Output`] is implemented for a number of tuples of different length.
 /// You can use this to combine other return-types that implement [`Output`].
 /// The following code for example retrieves the [`ExitStatus`]
 /// **and** what's written to `stdout`:

--- a/src/output.rs
+++ b/src/output.rs
@@ -14,7 +14,7 @@ use std::{process::ExitStatus, sync::Arc};
 /// assert_eq!(output, "foo\n");
 /// ```
 ///
-/// But if instead you want to capture the commands exit code,
+/// But if instead you want to capture the commands [`ExitStatus`],
 /// you can use [`Exit`]:
 ///
 /// ```
@@ -26,14 +26,14 @@ use std::{process::ExitStatus, sync::Arc};
 ///
 /// For documentation on what all the possible return types do,
 /// see the documentation for the individual impls of [`Output`].
-/// Here's a non-exhaustive list of the more commonly used return-types to get you started:
+/// Here's a non-exhaustive list of the more commonly used return types to get you started:
 ///
 /// - `()`: In case you don't want to capture anything. See also [`cmd_unit`].
 /// - [`StdoutUntrimmed`], [`StdoutTrimmed`] and [`Stderr`]: To capture `stdout` and `stderr`.
-/// - [`Exit`]: To capture the commands exit code.
+/// - [`Exit`]: To capture the commands [`ExitStatus`].
 ///
-/// Alse, [`Output`] is implemented for a number of tuples of different length.
-/// You can use this to combine other return-types that implement [`Output`].
+/// Alse, [`Output`] is implemented for a number of tuples of different lengths.
+/// You can use this to combine other return types that implement [`Output`].
 /// The following code for example retrieves the [`ExitStatus`]
 /// **and** what's written to `stdout`:
 ///

--- a/src/output.rs
+++ b/src/output.rs
@@ -4,8 +4,8 @@ use std::{process::ExitStatus, sync::Arc};
 /// All possible return types of [`cmd!`], [`cmd_unit!`] or
 /// [`cmd_result!`] must implement this trait.
 /// This return-type polymorphism makes cradle very flexible.
-/// For example if you want to capture what a command writes
-/// to its `stdout` you can do that using [`StdoutUntrimmed`]:
+/// For example, if you want to capture what a command writes
+/// to `stdout` you can do that using [`StdoutUntrimmed`]:
 ///
 /// ```
 /// use cradle::*;

--- a/src/output.rs
+++ b/src/output.rs
@@ -160,6 +160,9 @@ macro_rules! tuple_impl {
 tuple_impl!(A,);
 tuple_impl!(A, B,);
 tuple_impl!(A, B, C,);
+tuple_impl!(A, B, C, D,);
+tuple_impl!(A, B, C, D, E,);
+tuple_impl!(A, B, C, D, E, F,);
 
 /// See the [`Output`] implementation for [`Exit`] below.
 pub struct Exit(pub ExitStatus);

--- a/src/output.rs
+++ b/src/output.rs
@@ -29,7 +29,7 @@ use std::{process::ExitStatus, sync::Arc};
 /// Here's a non-exhaustive list of the more commonly used return types to get you started:
 ///
 /// - `()`: In case you don't want to capture anything. See also [`cmd_unit`].
-/// - [`StdoutUntrimmed`], [`StdoutTrimmed`] and [`Stderr`]: To capture `stdout` and `stderr`.
+/// - [`StdoutUntrimmed`], [`StdoutTrimmed`] and [`Stderr`]: To capture `stdout`, `stdout` trimmed of whitespace, and `stderr`.
 /// - [`Exit`]: To capture the commands [`ExitStatus`].
 ///
 /// Alse, [`Output`] is implemented for a number of tuples of different lengths.

--- a/src/output.rs
+++ b/src/output.rs
@@ -34,8 +34,8 @@ use std::{process::ExitStatus, sync::Arc};
 ///
 /// Also, [`Output`] is implemented for tuples.
 /// You can use this to combine multiple return types that implement [`Output`].
-/// The following code for example retrieves the [`ExitStatus`]
-/// **and** what's written to `stdout`:
+/// The following code for example retrieves the command's [`ExitStatus`]
+/// **and** what it writes to `stdout`:
 ///
 /// ```
 /// use cradle::*;


### PR DESCRIPTION
This PR tweaks the documentation for `Output`. Also -- since it's now easier to wade through the impls of `Output` -- it adds impls for longer tuples.
