### PR TITLE
Put primary macros into a `prelude` submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Here's an example:
 
 ``` rust
-use cradle::*;
+use cradle::prelude::*;
 
 fn main() {
     let StdoutTrimmed(git_version) = cmd!(%"git --version");

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -1,4 +1,4 @@
-use cradle::*;
+use cradle::prelude::*;
 
 fn main() {
     let StdoutTrimmed(git_version) = cmd!(%"git --version");

--- a/src/context_integration_tests.rs
+++ b/src/context_integration_tests.rs
@@ -1,7 +1,7 @@
 fn main() {
     #[cfg(unix)]
     {
-        use cradle::*;
+        use cradle::prelude::*;
         use executable_path::executable_path;
         use gag::BufferRedirect;
         use std::io::{self, Read};

--- a/src/error.rs
+++ b/src/error.rs
@@ -81,7 +81,7 @@ impl std::error::Error for Error {
 
 #[cfg(test)]
 mod tests {
-    use crate::{cmd_result, Stderr, StdoutUntrimmed};
+    use crate::prelude::{cmd_result, Stderr, StdoutUntrimmed};
     use executable_path::executable_path;
     use std::error::Error;
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,4 +1,5 @@
 use crate::config::Config;
+use crate::prelude::*;
 use std::{
     ffi::{OsStr, OsString},
     path::{Path, PathBuf},
@@ -12,7 +13,7 @@ use std::{
 /// and a variable number of arguments as a [`Vec`]:
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// let executable = "echo";
 /// let arguments = vec!["foo", "bar"];
@@ -63,7 +64,7 @@ where
 /// as arguments.
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// cmd_unit!("ls", std::env::var_os("HOME").unwrap());
 /// ```
@@ -78,7 +79,7 @@ impl Input for OsString {
 /// as arguments.
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// cmd_unit!("echo", std::env::current_dir().unwrap().file_name().unwrap());
 /// ```
@@ -95,7 +96,7 @@ impl Input for &OsStr {
 /// This is especially useful because it allows you to use string literals:
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// let StdoutTrimmed(output) = cmd!("echo", "foo");
 /// assert_eq!(output, "foo");
@@ -111,7 +112,7 @@ impl Input for &str {
 /// as arguments. Executables can also be passed as [`String`]s:
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// let executable: String = "echo".to_string();
 /// let argument: String = "foo".to_string();
@@ -132,7 +133,7 @@ pub struct Split<T: AsRef<str>>(pub T);
 /// and uses the resulting words as separate arguments.
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// let StdoutTrimmed(output) = cmd!(Split("echo foo"));
 /// assert_eq!(output, "foo");
@@ -145,7 +146,7 @@ pub struct Split<T: AsRef<str>>(pub T);
 /// for [`Split`], the `%` symbol:
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// let StdoutTrimmed(output) = cmd!(%"echo foo");
 /// assert_eq!(output, "foo");
@@ -164,7 +165,7 @@ impl<T: AsRef<str>> Input for Split<T> {
 /// Allows to use [`split`] to split your argument into words:
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// let StdoutTrimmed(output) = cmd!("echo foo".split(' '));
 /// assert_eq!(output, "foo");
@@ -185,7 +186,7 @@ impl<'a> Input for std::str::Split<'a, char> {
 /// Allows to use [`split_whitespace`] to split your argument into words:
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// let StdoutTrimmed(output) = cmd!("echo foo".split_whitespace());
 /// assert_eq!(output, "foo");
@@ -204,7 +205,7 @@ impl<'a> Input for std::str::SplitWhitespace<'a> {
 /// Allows to use [`split_ascii_whitespace`] to split your argument into words:
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// let StdoutTrimmed(output) = cmd!("echo foo".split_ascii_whitespace());
 /// assert_eq!(output, "foo");
@@ -224,7 +225,7 @@ impl<'a> Input for std::str::SplitAsciiWhitespace<'a> {
 /// Same as passing in the elements separately.
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// let StdoutTrimmed(output) = cmd!(vec!["echo", "foo"]);
 /// assert_eq!(output, "foo");
@@ -245,7 +246,7 @@ where
 /// All elements of the array will be used as arguments.
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// let StdoutTrimmed(output) = cmd!(["echo", "foo"]);
 /// assert_eq!(output, "foo");
@@ -286,7 +287,7 @@ pub struct LogCommand;
 /// (This is similar `bash`'s `-x` option.)
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// cmd_unit!(LogCommand, %"echo foo");
 /// // writes '+ echo foo' to stderr
@@ -305,7 +306,7 @@ pub struct CurrentDir<T: AsRef<Path>>(pub T);
 /// parent. You can override this with [`CurrentDir`]:
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// # #[cfg(linux)]
 /// # {
@@ -329,7 +330,7 @@ where
 /// as arguments.
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 /// use std::path::PathBuf;
 ///
 /// let current_dir: PathBuf = std::env::current_dir().unwrap();
@@ -346,7 +347,7 @@ impl Input for PathBuf {
 /// as arguments.
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 /// use std::path::Path;
 ///
 /// let file: &Path = Path::new("./foo");
@@ -367,7 +368,7 @@ pub struct Stdin<T: AsRef<[u8]>>(pub T);
 /// Writes the given byte slice to the child's standard input.
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// # #[cfg(linux)]
 /// # {

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,4 +1,5 @@
-use crate::{Config, Error, RunResult};
+use crate::prelude::*;
+use crate::{Config, RunResult};
 use std::{process::ExitStatus, sync::Arc};
 
 /// All possible return types of [`cmd!`], [`cmd_unit!`] or
@@ -8,7 +9,7 @@ use std::{process::ExitStatus, sync::Arc};
 /// to `stdout` you can do that using [`StdoutUntrimmed`]:
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// let StdoutUntrimmed(output) = cmd!(%"echo foo");
 /// assert_eq!(output, "foo\n");
@@ -18,7 +19,7 @@ use std::{process::ExitStatus, sync::Arc};
 /// you can use [`Exit`]:
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// let Exit(status) = cmd!("false");
 /// assert_eq!(status.code(), Some(1));
@@ -38,7 +39,7 @@ use std::{process::ExitStatus, sync::Arc};
 /// **and** what it writes to `stdout`:
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// let (Exit(status), StdoutUntrimmed(stdout)) = cmd!(%"echo foo");
 /// assert!(status.success());
@@ -85,7 +86,7 @@ pub struct StdoutTrimmed(pub String);
 ///
 /// ```
 /// use std::path::Path;
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// # #[cfg(unix)]
 /// # {
@@ -113,7 +114,7 @@ pub struct StdoutUntrimmed(pub String);
 /// Same as [`StdoutTrimmed`], but does not trim whitespace from the output:
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// let StdoutUntrimmed(output) = cmd!(%"echo foo");
 /// assert_eq!(output, "foo\n");
@@ -171,7 +172,7 @@ pub struct Exit(pub ExitStatus);
 /// retrieve the [`ExitStatus`] of the child process:
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// let Exit(status) = cmd!(%"echo foo");
 /// assert!(status.success());
@@ -181,11 +182,11 @@ pub struct Exit(pub ExitStatus);
 /// result in neither a panic nor a [`std::result::Result::Err`]:
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// let Exit(status) = cmd!("false");
 /// assert_eq!(status.code(), Some(1));
-/// let result: Result<Exit, cradle::Error> = cmd_result!("false");
+/// let result: Result<Exit, cradle::prelude::Error> = cmd_result!("false");
 /// assert!(result.is_ok());
 /// assert_eq!(result.unwrap().0.code(), Some(1));
 /// ```
@@ -212,7 +213,7 @@ pub struct Stderr(pub String);
 /// [`Stderr`] allows to capture the `stderr` of a child process:
 ///
 /// ```
-/// use cradle::*;
+/// use cradle::prelude::*;
 ///
 /// // (`Exit` is used here to suppress panics caused by `ls`
 /// // terminating with a non-zero exit code.)

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,35 @@
+pub use crate::{
+    error::{panic_on_error, Error},
+    input::{CurrentDir, Input, LogCommand, Split, Stdin},
+    output::{Exit, Output, Stderr, StdoutTrimmed, StdoutUntrimmed},
+};
+
+/// Execute child processes. See the module documentation on how to use it.
+#[macro_export]
+macro_rules! _cmd {
+    ($($args:tt)*) => {{
+        let context = $crate::Context::production();
+        $crate::prelude::panic_on_error($crate::cmd_result_with_context!(context, $($args)*))
+    }}
+}
+pub use _cmd as cmd;
+
+/// Like [`cmd!`], but fixes the return type to `()`.
+#[macro_export]
+macro_rules! _cmd_unit {
+    ($($args:tt)*) => {{
+        let () = $crate::_cmd!($($args)*);
+    }}
+}
+pub use _cmd_unit as cmd_unit;
+
+/// Like [`cmd!`], but fixes the return type to [`Result<T, Error>`],
+/// where `T` is any type that implements [`Output`].
+#[macro_export]
+macro_rules! _cmd_result {
+    ($($args:tt)*) => {{
+        let context = $crate::Context::production();
+        $crate::cmd_result_with_context!(context, $($args)*)
+    }}
+}
+pub use _cmd_result as cmd_result;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7,7 +7,7 @@ const WHICH: &str = "where";
 
 #[test]
 fn capturing_stdout() {
-    use cradle::*;
+    use cradle::prelude::*;
 
     let StdoutTrimmed(output) = cmd!(%"echo foo");
     assert_eq!(output, "foo");
@@ -16,14 +16,14 @@ fn capturing_stdout() {
 #[test]
 #[should_panic(expected = "false:\n  exited with exit code: 1")]
 fn panics_on_non_zero_exit_codes() {
-    use cradle::*;
+    use cradle::prelude::*;
 
     cmd_unit!("false");
 }
 
 #[test]
 fn result_succeeding() {
-    use cradle::*;
+    use cradle::prelude::*;
 
     fn test() -> Result<(), Error> {
         // make sure 'ls' is installed
@@ -36,7 +36,7 @@ fn result_succeeding() {
 
 #[test]
 fn result_failing() {
-    use cradle::*;
+    use cradle::prelude::*;
 
     fn test() -> Result<(), Error> {
         cmd_result!(WHICH, "does-not-exist")?;
@@ -55,7 +55,7 @@ fn result_failing() {
 
 #[test]
 fn trimmed_stdout() {
-    use cradle::*;
+    use cradle::prelude::*;
     use std::path::PathBuf;
 
     {
@@ -70,7 +70,7 @@ fn trimmed_stdout() {
 
 #[test]
 fn trimmed_stdout_and_results() {
-    use cradle::*;
+    use cradle::prelude::*;
     use std::path::PathBuf;
 
     fn test() -> Result<(), Error> {
@@ -88,7 +88,7 @@ fn trimmed_stdout_and_results() {
 
 #[test]
 fn box_dyn_errors_succeeding() {
-    use cradle::*;
+    use cradle::prelude::*;
 
     type MyResult<T> = Result<T, Box<dyn std::error::Error>>;
 
@@ -102,7 +102,7 @@ fn box_dyn_errors_succeeding() {
 
 #[test]
 fn box_dyn_errors_failing() {
-    use cradle::*;
+    use cradle::prelude::*;
 
     type MyResult<T> = Result<T, Box<dyn std::error::Error>>;
 
@@ -123,15 +123,15 @@ fn box_dyn_errors_failing() {
 
 #[test]
 fn user_supplied_errors_succeeding() {
-    use cradle::*;
+    use cradle::prelude::*;
 
     #[derive(Debug)]
     enum Error {
-        CmdError(cradle::Error),
+        CmdError(cradle::prelude::Error),
     }
 
-    impl From<cradle::Error> for Error {
-        fn from(error: cradle::Error) -> Self {
+    impl From<cradle::prelude::Error> for Error {
+        fn from(error: cradle::prelude::Error) -> Self {
             Error::CmdError(error)
         }
     }
@@ -146,15 +146,15 @@ fn user_supplied_errors_succeeding() {
 
 #[test]
 fn user_supplied_errors_failing() {
-    use cradle::*;
+    use cradle::prelude::*;
 
     #[derive(Debug)]
     enum Error {
-        CmdError(cradle::Error),
+        CmdError(cradle::prelude::Error),
     }
 
-    impl From<cradle::Error> for Error {
-        fn from(error: cradle::Error) -> Self {
+    impl From<cradle::prelude::Error> for Error {
+        fn from(error: cradle::prelude::Error) -> Self {
             Error::CmdError(error)
         }
     }


### PR DESCRIPTION
This is an attempt to put the primary interface -- the items that most people will use and need to import -- into a `prelude` submodule. So that users can do `use cradle::prelude::*;`. This has some disadvantages, so I don't think this will ever get merged. The dealbreaker seems to be this:

Even if macros are declared in a submodule, rust puts them into the top module of a crate. Here I'm using this re-exporting hack to work around that, but that seems like a terrible idea. Also, I haven't checked what it does to generated documentation.