### PR TITLE
Rename `Exit` to `Status`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ use cradle::*;
 fn main() {
     let StdoutTrimmed(git_version) = cmd!(%"git --version");
     eprintln!("git version: {}", git_version);
-    let (StdoutTrimmed(git_user), Exit(status)) = cmd!(%"git config --get user.name");
+    let (StdoutTrimmed(git_user), Status(status)) = cmd!(%"git config --get user.name");
     if status.success() {
         eprintln!("git user: {}", git_user);
     } else {

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -3,7 +3,7 @@ use cradle::*;
 fn main() {
     let StdoutTrimmed(git_version) = cmd!(%"git --version");
     eprintln!("git version: {}", git_version);
-    let (StdoutTrimmed(git_user), Exit(status)) = cmd!(%"git config --get user.name");
+    let (StdoutTrimmed(git_user), Status(status)) = cmd!(%"git config --get user.name");
     if status.success() {
         eprintln!("git user: {}", git_user);
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -986,8 +986,8 @@ mod tests {
 
         #[test]
         fn failing_commands_return_oks_when_exit_status_is_captured() {
-            let Status(status) = cmd_result!("false").unwrap();
-            assert!(!status.success());
+            let Status(exit_status) = cmd_result!("false").unwrap();
+            assert!(!exit_status.success());
         }
     }
 
@@ -1025,63 +1025,63 @@ mod tests {
 
         #[test]
         fn two_tuple_1() {
-            let (StdoutTrimmed(output), Status(status)) = cmd!(
+            let (StdoutTrimmed(output), Status(exit_status)) = cmd!(
                 executable_path("cradle_test_helper"),
                 "output foo and exit with 42"
             );
             assert_eq!(output, "foo");
-            assert_eq!(status.code(), Some(42));
+            assert_eq!(exit_status.code(), Some(42));
         }
 
         #[test]
         fn two_tuple_2() {
-            let (Status(status), StdoutTrimmed(output)) = cmd!(
+            let (Status(exit_status), StdoutTrimmed(output)) = cmd!(
                 executable_path("cradle_test_helper"),
                 "output foo and exit with 42"
             );
             assert_eq!(output, "foo");
-            assert_eq!(status.code(), Some(42));
+            assert_eq!(exit_status.code(), Some(42));
         }
 
         #[test]
         fn result_of_tuple() {
-            let (StdoutTrimmed(output), Status(status)) = cmd_result!(%"echo foo").unwrap();
+            let (StdoutTrimmed(output), Status(exit_status)) = cmd_result!(%"echo foo").unwrap();
             assert_eq!(output, "foo");
-            assert!(status.success());
+            assert!(exit_status.success());
         }
 
         #[test]
         fn result_of_tuple_when_erroring() {
-            let (StdoutTrimmed(output), Status(status)) = cmd_result!("false").unwrap();
+            let (StdoutTrimmed(output), Status(exit_status)) = cmd_result!("false").unwrap();
             assert_eq!(output, "");
-            assert_eq!(status.code(), Some(1));
+            assert_eq!(exit_status.code(), Some(1));
         }
 
         #[test]
         fn three_tuples() {
-            let (Stderr(stderr), StdoutTrimmed(stdout), Status(status)) = cmd!(%"echo foo");
+            let (Stderr(stderr), StdoutTrimmed(stdout), Status(exit_status)) = cmd!(%"echo foo");
             assert_eq!(stderr, "");
             assert_eq!(stdout, "foo");
-            assert_eq!(status.code(), Some(0));
+            assert_eq!(exit_status.code(), Some(0));
         }
 
         #[test]
         fn capturing_stdout_on_errors() {
-            let (StdoutTrimmed(output), Status(status)) = cmd!(
+            let (StdoutTrimmed(output), Status(exit_status)) = cmd!(
                 executable_path("cradle_test_helper"),
                 "output foo and exit with 42"
             );
-            assert!(!status.success());
+            assert!(!exit_status.success());
             assert_eq!(output, "foo");
         }
 
         #[test]
         fn capturing_stderr_on_errors() {
-            let (Stderr(output), Status(status)) = cmd!(
+            let (Stderr(output), Status(exit_status)) = cmd!(
                 executable_path("cradle_test_helper"),
                 "write to stderr and exit with 42"
             );
-            assert!(!status.success());
+            assert!(!exit_status.success());
             assert_eq!(output, "foo\n");
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,12 +121,12 @@
 //! ```
 //!
 //! You can suppress panics caused by non-zero exit codes by using the
-//! [`Exit`] type as a return type of [`cmd!`]:
+//! [`Status`] type as a return type of [`cmd!`]:
 //!
 //! ```
 //! use cradle::*;
 //!
-//! let Exit(exit_status) = cmd!("false");
+//! let Status(exit_status) = cmd!("false");
 //! assert_eq!(exit_status.code(), Some(1));
 //! ```
 //!
@@ -186,7 +186,7 @@ pub use crate::{config::Config, context::Context};
 pub use crate::{
     error::{panic_on_error, Error},
     input::{CurrentDir, Input, LogCommand, Split, Stdin},
-    output::{Exit, Output, Stderr, StdoutTrimmed, StdoutUntrimmed},
+    output::{Output, Status, Stderr, StdoutTrimmed, StdoutUntrimmed},
 };
 use std::{
     ffi::OsString,
@@ -967,26 +967,26 @@ mod tests {
 
         #[test]
         fn zero() {
-            let Exit(exit_status) = cmd!("true");
+            let Status(exit_status) = cmd!("true");
             assert!(exit_status.success());
         }
 
         #[test]
         fn one() {
-            let Exit(exit_status) = cmd!("false");
+            let Status(exit_status) = cmd!("false");
             assert!(!exit_status.success());
         }
 
         #[test]
         fn forty_two() {
-            let Exit(exit_status) = cmd!(executable_path("cradle_test_helper"), "exit code 42");
+            let Status(exit_status) = cmd!(executable_path("cradle_test_helper"), "exit code 42");
             assert!(!exit_status.success());
             assert_eq!(exit_status.code(), Some(42));
         }
 
         #[test]
         fn failing_commands_return_oks_when_exit_status_is_captured() {
-            let Exit(status) = cmd_result!("false").unwrap();
+            let Status(status) = cmd_result!("false").unwrap();
             assert!(!status.success());
         }
     }
@@ -1025,7 +1025,7 @@ mod tests {
 
         #[test]
         fn two_tuple_1() {
-            let (StdoutTrimmed(output), Exit(status)) = cmd!(
+            let (StdoutTrimmed(output), Status(status)) = cmd!(
                 executable_path("cradle_test_helper"),
                 "output foo and exit with 42"
             );
@@ -1035,7 +1035,7 @@ mod tests {
 
         #[test]
         fn two_tuple_2() {
-            let (Exit(status), StdoutTrimmed(output)) = cmd!(
+            let (Status(status), StdoutTrimmed(output)) = cmd!(
                 executable_path("cradle_test_helper"),
                 "output foo and exit with 42"
             );
@@ -1045,21 +1045,21 @@ mod tests {
 
         #[test]
         fn result_of_tuple() {
-            let (StdoutTrimmed(output), Exit(status)) = cmd_result!(%"echo foo").unwrap();
+            let (StdoutTrimmed(output), Status(status)) = cmd_result!(%"echo foo").unwrap();
             assert_eq!(output, "foo");
             assert!(status.success());
         }
 
         #[test]
         fn result_of_tuple_when_erroring() {
-            let (StdoutTrimmed(output), Exit(status)) = cmd_result!("false").unwrap();
+            let (StdoutTrimmed(output), Status(status)) = cmd_result!("false").unwrap();
             assert_eq!(output, "");
             assert_eq!(status.code(), Some(1));
         }
 
         #[test]
         fn three_tuples() {
-            let (Stderr(stderr), StdoutTrimmed(stdout), Exit(status)) = cmd!(%"echo foo");
+            let (Stderr(stderr), StdoutTrimmed(stdout), Status(status)) = cmd!(%"echo foo");
             assert_eq!(stderr, "");
             assert_eq!(stdout, "foo");
             assert_eq!(status.code(), Some(0));
@@ -1067,7 +1067,7 @@ mod tests {
 
         #[test]
         fn capturing_stdout_on_errors() {
-            let (StdoutTrimmed(output), Exit(status)) = cmd!(
+            let (StdoutTrimmed(output), Status(status)) = cmd!(
                 executable_path("cradle_test_helper"),
                 "output foo and exit with 42"
             );
@@ -1077,7 +1077,7 @@ mod tests {
 
         #[test]
         fn capturing_stderr_on_errors() {
-            let (Stderr(output), Exit(status)) = cmd!(
+            let (Stderr(output), Status(status)) = cmd!(
                 executable_path("cradle_test_helper"),
                 "write to stderr and exit with 42"
             );

--- a/src/output.rs
+++ b/src/output.rs
@@ -15,12 +15,12 @@ use std::{process::ExitStatus, sync::Arc};
 /// ```
 ///
 /// But if instead you want to capture the command's [`ExitStatus`],
-/// you can use [`Exit`]:
+/// you can use [`Status`]:
 ///
 /// ```
 /// use cradle::*;
 ///
-/// let Exit(status) = cmd!("false");
+/// let Status(status) = cmd!("false");
 /// assert_eq!(status.code(), Some(1));
 /// ```
 ///
@@ -30,7 +30,7 @@ use std::{process::ExitStatus, sync::Arc};
 ///
 /// - `()`: In case you don't want to capture anything. See also [`cmd_unit`].
 /// - [`StdoutUntrimmed`], [`StdoutTrimmed`] and [`Stderr`]: To capture `stdout`, `stdout` trimmed of whitespace, and `stderr`.
-/// - [`Exit`]: To capture the command's [`ExitStatus`].
+/// - [`Status`]: To capture the command's [`ExitStatus`].
 ///
 /// Also, [`Output`] is implemented for tuples.
 /// You can use this to combine multiple return types that implement [`Output`].
@@ -40,7 +40,7 @@ use std::{process::ExitStatus, sync::Arc};
 /// ```
 /// use cradle::*;
 ///
-/// let (Exit(status), StdoutUntrimmed(stdout)) = cmd!(%"echo foo");
+/// let (Status(status), StdoutUntrimmed(stdout)) = cmd!(%"echo foo");
 /// assert!(status.success());
 /// assert_eq!(stdout, "foo\n");
 /// ```
@@ -48,7 +48,7 @@ use std::{process::ExitStatus, sync::Arc};
 /// [`StdoutUntrimmed`]: trait.Output.html#impl-Output-3
 /// [`StdoutTrimmed`]: trait.Output.html#impl-Output-2
 /// [`Stderr`]: trait.Output.html#impl-Output-1
-/// [`Exit`]: trait.Output.html#impl-Output
+/// [`Status`]: trait.Output.html#impl-Output
 pub trait Output: Sized {
     #[doc(hidden)]
     fn configure(config: &mut Config);
@@ -164,28 +164,28 @@ tuple_impl!(A, B, C, D,);
 tuple_impl!(A, B, C, D, E,);
 tuple_impl!(A, B, C, D, E, F,);
 
-/// See the [`Output`] implementation for [`Exit`] below.
-pub struct Exit(pub ExitStatus);
+/// See the [`Output`] implementation for [`Status`] below.
+pub struct Status(pub ExitStatus);
 
-/// Using [`Exit`] as the return type for [`cmd!`] allows to
+/// Using [`Status`] as the return type for [`cmd!`] allows to
 /// retrieve the [`ExitStatus`] of the child process:
 ///
 /// ```
 /// use cradle::*;
 ///
-/// let Exit(status) = cmd!(%"echo foo");
+/// let Status(status) = cmd!(%"echo foo");
 /// assert!(status.success());
 /// ```
 ///
-/// Also, when using [`Exit`], non-zero exit codes won't
+/// Also, when using [`Status`], non-zero exit codes won't
 /// result in neither a panic nor a [`std::result::Result::Err`]:
 ///
 /// ```
 /// use cradle::*;
 ///
-/// let Exit(status) = cmd!("false");
+/// let Status(status) = cmd!("false");
 /// assert_eq!(status.code(), Some(1));
-/// let result: Result<Exit, cradle::Error> = cmd_result!("false");
+/// let result: Result<Status, cradle::Error> = cmd_result!("false");
 /// assert!(result.is_ok());
 /// assert_eq!(result.unwrap().0.code(), Some(1));
 /// ```
@@ -193,7 +193,7 @@ pub struct Exit(pub ExitStatus);
 /// Also see the
 /// [section about error handling](index.html#error-handling) in
 /// the module documentation.
-impl Output for Exit {
+impl Output for Status {
     #[doc(hidden)]
     fn configure(config: &mut Config) {
         config.error_on_non_zero_exit_code = false;
@@ -201,7 +201,7 @@ impl Output for Exit {
 
     #[doc(hidden)]
     fn from_run_result(_config: &Config, result: Result<RunResult, Error>) -> Result<Self, Error> {
-        Ok(Exit(result?.exit_status))
+        Ok(Status(result?.exit_status))
     }
 }
 
@@ -214,9 +214,9 @@ pub struct Stderr(pub String);
 /// ```
 /// use cradle::*;
 ///
-/// // (`Exit` is used here to suppress panics caused by `ls`
+/// // (`Status` is used here to suppress panics caused by `ls`
 /// // terminating with a non-zero exit code.)
-/// let (Stderr(stderr), Exit(_)) = cmd!(%"ls does-not-exist");
+/// let (Stderr(stderr), Status(_)) = cmd!(%"ls does-not-exist");
 /// assert!(stderr.contains("No such file or directory"));
 /// ```
 ///

--- a/src/output.rs
+++ b/src/output.rs
@@ -20,8 +20,8 @@ use std::{process::ExitStatus, sync::Arc};
 /// ```
 /// use cradle::*;
 ///
-/// let Status(status) = cmd!("false");
-/// assert_eq!(status.code(), Some(1));
+/// let Status(exit_status) = cmd!("false");
+/// assert_eq!(exit_status.code(), Some(1));
 /// ```
 ///
 /// For documentation on what all the possible return types do,
@@ -40,8 +40,8 @@ use std::{process::ExitStatus, sync::Arc};
 /// ```
 /// use cradle::*;
 ///
-/// let (Status(status), StdoutUntrimmed(stdout)) = cmd!(%"echo foo");
-/// assert!(status.success());
+/// let (Status(exit_status), StdoutUntrimmed(stdout)) = cmd!(%"echo foo");
+/// assert!(exit_status.success());
 /// assert_eq!(stdout, "foo\n");
 /// ```
 ///
@@ -173,8 +173,8 @@ pub struct Status(pub ExitStatus);
 /// ```
 /// use cradle::*;
 ///
-/// let Status(status) = cmd!(%"echo foo");
-/// assert!(status.success());
+/// let Status(exit_status) = cmd!(%"echo foo");
+/// assert!(exit_status.success());
 /// ```
 ///
 /// Also, when using [`Status`], non-zero exit codes won't
@@ -183,8 +183,8 @@ pub struct Status(pub ExitStatus);
 /// ```
 /// use cradle::*;
 ///
-/// let Status(status) = cmd!("false");
-/// assert_eq!(status.code(), Some(1));
+/// let Status(exit_status) = cmd!("false");
+/// assert_eq!(exit_status.code(), Some(1));
 /// let result: Result<Status, cradle::Error> = cmd_result!("false");
 /// assert!(result.is_ok());
 /// assert_eq!(result.unwrap().0.code(), Some(1));


### PR DESCRIPTION
- Rename Exit to Status
- Rename `Status(status)` to `Status(exit_status)` in patterns
