### PR TITLE
Add categories to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 repository = "https://github.com/soenkehahn/cradle"
 homepage = "https://github.com/soenkehahn/cradle"
 keywords = ["child", "child-process", "command", "process", "shell"]
+categories = ["filesystem", "os"]
 
 [dependencies]
 rustversion = "1.0.4"


### PR DESCRIPTION
I think these are the most fitting of the available [categories](https://crates.io/categories). Not sure whether it's better to add them or leave them off though.