### PR TITLE
Add .run() and friends to Input

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -97,6 +97,13 @@ pub trait Input {
     {
         crate::cmd!(self)
     }
+
+    fn run_unit(self)
+    where
+        Self: Sized,
+    {
+        crate::cmd_unit!(self);
+    }
 }
 
 /// Blanket implementation for `&_`.

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,4 +1,4 @@
-use crate::config::Config;
+use crate::{config::Config, output::Output};
 use std::{
     ffi::{OsStr, OsString},
     path::{Path, PathBuf},
@@ -89,6 +89,14 @@ use std::{
 pub trait Input {
     #[doc(hidden)]
     fn configure(self, config: &mut Config);
+
+    fn run<O>(self) -> O
+    where
+        Self: Sized,
+        O: Output,
+    {
+        crate::cmd!(self)
+    }
 }
 
 /// Blanket implementation for `&_`.

--- a/src/input.rs
+++ b/src/input.rs
@@ -93,7 +93,15 @@ pub trait Input {
     #[doc(hidden)]
     fn configure(self, config: &mut Config);
 
-    /// todo
+    /// `input.run()` runs `input` as a child process.
+    /// It's equivalent to `cmd!(input)`.
+    ///
+    /// ```
+    /// use cradle::prelude::*;
+    ///
+    /// let StdoutTrimmed(output) = ("echo", "foo").run();
+    /// assert_eq!(output, "foo");
+    /// ```
     fn run<O>(self) -> O
     where
         Self: Sized,
@@ -102,7 +110,16 @@ pub trait Input {
         crate::cmd!(self)
     }
 
-    /// todo
+    /// `input.run_unit()` runs `input` as a child process.
+    /// It's equivalent to `cmd_unit!(input)`.
+    ///
+    /// ```
+    /// # let temp_dir = tempfile::TempDir::new().unwrap();
+    /// # std::env::set_current_dir(&temp_dir).unwrap();
+    /// use cradle::prelude::*;
+    ///
+    /// ("touch", "foo").run_unit();
+    /// ```
     fn run_unit(self)
     where
         Self: Sized,
@@ -110,7 +127,21 @@ pub trait Input {
         crate::cmd_unit!(self);
     }
 
-    /// todo
+    /// `input.run_result()` runs `input` as a child process.
+    /// It's equivalent to `cmd_result!(input)`.
+    ///
+    /// ```
+    /// use cradle::prelude::*;
+    ///
+    /// # fn build() -> Result<(), Error> {
+    /// // make sure build tools are installed
+    /// cmd_result!(%"which make")?;
+    /// cmd_result!(%"which gcc")?;
+    /// cmd_result!(%"which ld")?;
+    /// cmd_result!(%"make build")?;
+    /// # Ok(())
+    /// # }
+    /// ```
     fn run_result<O>(self) -> Result<O, crate::error::Error>
     where
         Self: Sized,

--- a/src/input.rs
+++ b/src/input.rs
@@ -104,6 +104,14 @@ pub trait Input {
     {
         crate::cmd_unit!(self);
     }
+
+    fn run_result<O>(self) -> Result<O, crate::error::Error>
+    where
+        Self: Sized,
+        O: Output,
+    {
+        crate::cmd_result!(self)
+    }
 }
 
 /// Blanket implementation for `&_`.

--- a/src/input.rs
+++ b/src/input.rs
@@ -90,6 +90,7 @@ pub trait Input {
     #[doc(hidden)]
     fn configure(self, config: &mut Config);
 
+    /// todo
     fn run<O>(self) -> O
     where
         Self: Sized,
@@ -98,6 +99,7 @@ pub trait Input {
         crate::cmd!(self)
     }
 
+    /// todo
     fn run_unit(self)
     where
         Self: Sized,
@@ -105,6 +107,7 @@ pub trait Input {
         crate::cmd_unit!(self);
     }
 
+    /// todo
     fn run_result<O>(self) -> Result<O, crate::error::Error>
     where
         Self: Sized,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -642,7 +642,7 @@ mod tests {
                     Err(Error::FileNotFoundWhenExecuting { executable, .. }) => {
                         assert_eq!(executable, "does-not-exist");
                     }
-                    _ => panic!("should match Error::ExecutableNotFound"),
+                    _ => panic!("should match Error::FileNotFoundWhenExecuting"),
                 }
             }
 
@@ -653,7 +653,7 @@ mod tests {
                     Err(Error::FileNotFoundWhenExecuting { executable, .. }) => {
                         assert_eq!(executable, "./does-not-exist");
                     }
-                    _ => panic!("should match Error::ExecutableNotFound"),
+                    _ => panic!("should match Error::FileNotFoundWhenExecuting"),
                 }
             }
 
@@ -1613,10 +1613,10 @@ mod tests {
             let StdoutTrimmed(output) = ("echo", "foo").run_result().unwrap();
             assert_eq!(output, "foo");
             let result: Result<(), Error> = "does-not-exist".run_result();
-            assert!(matches!(
-                result,
-                Err(Error::FileNotFoundWhenExecuting { .. })
-            ));
+            match result {
+                Err(Error::FileNotFoundWhenExecuting { .. }) => {}
+                _ => panic!("should match Error::FileNotFoundWhenExecuting"),
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,13 +184,13 @@
 //! Here's some examples:
 //!
 //! ```
+//! # let temp_dir = tempfile::TempDir::new().unwrap();
+//! # std::env::set_current_dir(&temp_dir).unwrap();
 //! use cradle::prelude::*;
 //!
 //! let StdoutTrimmed(output) = ("echo", "foo").run();
 //! assert_eq!(output, "foo");
 //!
-//! # let temp_dir = tempfile::TempDir::new().unwrap();
-//! # std::env::set_current_dir(&temp_dir).unwrap();
 //! ("touch", "foo").run_unit();
 //!
 //! let result: Result<(), cradle::Error> = "false".run_result();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1570,5 +1570,16 @@ mod tests {
                 assert!(Path::new("foo").exists());
             });
         }
+
+        #[test]
+        fn run_result() {
+            let StdoutTrimmed(output) = ("echo", "foo").run_result().unwrap();
+            assert_eq!(output, "foo");
+            let result: Result<(), Error> = "does-not-exist".run_result();
+            assert!(matches!(
+                result,
+                Err(Error::FileNotFoundWhenExecuting { .. })
+            ));
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1543,6 +1543,7 @@ mod tests {
 
     mod run_interface {
         use super::*;
+        use std::path::Path;
 
         #[test]
         fn allows_to_run_commands_with_dot_run() {
@@ -1554,6 +1555,20 @@ mod tests {
         fn allows_to_boundle_arguments_up_in_tuples() {
             let StdoutTrimmed(output) = ("echo", "foo").run();
             assert_eq!(output, "foo");
+        }
+
+        #[test]
+        fn works_for_different_output_types() {
+            let Status(status) = "false".run();
+            assert_eq!(status.success(), false);
+        }
+
+        #[test]
+        fn run_unit() {
+            in_temporary_directory(|| {
+                ("touch", "foo").run_unit();
+                assert!(Path::new("foo").exists());
+            });
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,42 @@
 //! }
 //! ```
 //!
+//! # Alternative interface
+//!
+//! `cradle` also provides an alternative interface to execute commands
+//! through methods on the [`Input`] trait:
+//! [`.run()`](Input::run), [`.run_unit()`](Input::run_unit)
+//! and [`.run_result()`](Input::run_result).
+//! These methods can be invoked on all values whose types implement [`Input`].
+//! When using these methods, it's especially useful that [`Input`] is implemented
+//! by tuples.
+//! The work analog to [`cmd!`], [`cmd_unit!`] and [`cmd_result!`].
+//! Here's some examples:
+//!
+//! ```
+//! let StdoutTrimmed(output) = ("echo", "foo").run();
+//! assert_eq!(output, "foo");
+//!
+//! # let temp_dir = tempfile::TempDir::new().unwrap();
+//! # std::env::set_current_dir(&temp_dir).unwrap();
+//! ("touch", "foo").run_unit();
+//!
+//! let result: Result<(), cradle::Error> = "false".run_result();
+//! let error_message = format!("{}", result.unwrap_err());
+//! assert_eq!(
+//!     error_message,
+//!     "false:\n  exited with exit code: 1"
+//! );
+//! ```
+//!
+//! Note: The `%` shortcut for [`Split`] is not available in this notation.
+//! You can either use tuples, or [`Split`] explicitly:
+//!
+//! ```
+//! Split("echo foo").run_unit();
+//! ("echo", "foo").run_unit();
+//! ```
+//!
 //! # Prior Art
 //!
 //! `cradle` is heavily inspired by [shake](https://shakebuild.com/),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,8 +180,8 @@
 //! [`Input`](input::Input).
 //! When using these methods, it's especially useful that
 //! [`Input`](input::Input) is implemented by tuples.
-//! The work analog to [`cmd!`], [`cmd_unit!`] and [`cmd_result!`].
-//! Here's some examples:
+//! They work analog to [`cmd!`], [`cmd_unit!`] and [`cmd_result!`].
+//! Here are some examples:
 //!
 //! ```
 //! # let temp_dir = tempfile::TempDir::new().unwrap();
@@ -207,8 +207,8 @@
 //! ```
 //! use cradle::prelude::*;
 //!
-//! Split("echo foo").run_unit();
 //! ("echo", "foo").run_unit();
+//! Split("echo foo").run_unit();
 //! ```
 //!
 //! # Prior Art
@@ -1589,7 +1589,7 @@ mod tests {
         }
 
         #[test]
-        fn allows_to_boundle_arguments_up_in_tuples() {
+        fn allows_to_bundle_arguments_up_in_tuples() {
             let StdoutTrimmed(output) = ("echo", "foo").run();
             assert_eq!(output, "foo");
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1540,4 +1540,20 @@ mod tests {
             assert_eq!(output, "empty variable: FOO\n");
         }
     }
+
+    mod run_interface {
+        use super::*;
+
+        #[test]
+        fn allows_to_run_commands_with_dot_run() {
+            let StdoutTrimmed(output) = Split("echo foo").run();
+            assert_eq!(output, "foo");
+        }
+
+        #[test]
+        fn allows_to_boundle_arguments_up_in_tuples() {
+            let StdoutTrimmed(output) = ("echo", "foo").run();
+            assert_eq!(output, "foo");
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,16 +173,19 @@
 //! # Alternative interface
 //!
 //! `cradle` also provides an alternative interface to execute commands
-//! through methods on the [`Input`] trait:
-//! [`.run()`](Input::run), [`.run_unit()`](Input::run_unit)
-//! and [`.run_result()`](Input::run_result).
-//! These methods can be invoked on all values whose types implement [`Input`].
-//! When using these methods, it's especially useful that [`Input`] is implemented
-//! by tuples.
+//! through methods on the [`Input`](input::Input) trait:
+//! [`.run()`](input::Input::run), [`.run_unit()`](input::Input::run_unit)
+//! and [`.run_result()`](input::Input::run_result).
+//! These methods can be invoked on all values whose types implement
+//! [`Input`](input::Input).
+//! When using these methods, it's especially useful that
+//! [`Input`](input::Input) is implemented by tuples.
 //! The work analog to [`cmd!`], [`cmd_unit!`] and [`cmd_result!`].
 //! Here's some examples:
 //!
 //! ```
+//! use cradle::prelude::*;
+//!
 //! let StdoutTrimmed(output) = ("echo", "foo").run();
 //! assert_eq!(output, "foo");
 //!
@@ -198,10 +201,12 @@
 //! );
 //! ```
 //!
-//! Note: The `%` shortcut for [`Split`] is not available in this notation.
-//! You can either use tuples, or [`Split`] explicitly:
+//! Note: The `%` shortcut for [`Split`](input::Split) is not available in this notation.
+//! You can either use tuples, or [`Split`](input::Split) explicitly:
 //!
 //! ```
+//! use cradle::prelude::*;
+//!
 //! Split("echo foo").run_unit();
 //! ("echo", "foo").run_unit();
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1560,7 +1560,7 @@ mod tests {
         #[test]
         fn works_for_different_output_types() {
             let Status(status) = "false".run();
-            assert_eq!(status.success(), false);
+            assert!(!status.success());
         }
 
         #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-
 #[cfg(unix)]
 const WHICH: &str = "which";
 #[cfg(windows)]
@@ -147,6 +145,7 @@ fn user_supplied_errors_succeeding() {
 #[test]
 fn user_supplied_errors_failing() {
     use cradle::*;
+    use std::fmt::Display;
 
     #[derive(Debug)]
     enum Error {
@@ -180,4 +179,137 @@ fn user_supplied_errors_failing() {
             "cmd-error: where does-not-exist:\n  exited with exit code: 1"
         }
     );
+}
+
+mod run_interface {
+    use super::*;
+
+    #[test]
+    fn result_succeeding() {
+        use cradle::*;
+
+        fn test() -> Result<(), Error> {
+            // make sure 'ls' is installed
+            (WHICH, "ls").run_result()?;
+            Ok(())
+        }
+
+        test().unwrap();
+    }
+
+    #[test]
+    fn result_failing() {
+        use cradle::*;
+
+        fn test() -> Result<(), Error> {
+            (WHICH, "does-not-exist").run_result()?;
+            Ok(())
+        }
+
+        assert_eq!(
+            test().unwrap_err().to_string(),
+            if cfg!(unix) {
+                "which does-not-exist:\n  exited with exit code: 1"
+            } else {
+                "where does-not-exist:\n  exited with exit code: 1"
+            }
+        );
+    }
+
+    #[test]
+    fn box_dyn_errors_succeeding() {
+        use cradle::*;
+
+        type MyResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+        fn test() -> MyResult<()> {
+            (WHICH, "ls").run_result()?;
+            Ok(())
+        }
+
+        test().unwrap();
+    }
+
+    #[test]
+    fn box_dyn_errors_failing() {
+        use cradle::*;
+
+        type MyResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+        fn test() -> MyResult<()> {
+            (WHICH, "does-not-exist").run_result()?;
+            Ok(())
+        }
+
+        assert_eq!(
+            test().unwrap_err().to_string(),
+            if cfg!(unix) {
+                "which does-not-exist:\n  exited with exit code: 1"
+            } else {
+                "where does-not-exist:\n  exited with exit code: 1"
+            }
+        );
+    }
+
+    #[test]
+    fn user_supplied_errors_succeeding() {
+        use cradle::*;
+
+        #[derive(Debug)]
+        enum Error {
+            CmdError(cradle::Error),
+        }
+
+        impl From<cradle::Error> for Error {
+            fn from(error: cradle::Error) -> Self {
+                Error::CmdError(error)
+            }
+        }
+
+        fn test() -> Result<(), Error> {
+            (WHICH, "ls").run_result()?;
+            Ok(())
+        }
+
+        test().unwrap();
+    }
+
+    #[test]
+    fn user_supplied_errors_failing() {
+        use cradle::*;
+        use std::fmt::Display;
+
+        #[derive(Debug)]
+        enum Error {
+            CmdError(cradle::Error),
+        }
+
+        impl From<cradle::Error> for Error {
+            fn from(error: cradle::Error) -> Self {
+                Error::CmdError(error)
+            }
+        }
+
+        impl Display for Error {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self {
+                    Error::CmdError(error) => write!(f, "cmd-error: {}", error),
+                }
+            }
+        }
+
+        fn test() -> Result<(), Error> {
+            (WHICH, "does-not-exist").run_result()?;
+            Ok(())
+        }
+
+        assert_eq!(
+            test().unwrap_err().to_string(),
+            if cfg!(unix) {
+                "cmd-error: which does-not-exist:\n  exited with exit code: 1"
+            } else {
+                "cmd-error: where does-not-exist:\n  exited with exit code: 1"
+            }
+        );
+    }
 }


### PR DESCRIPTION
This PR adds `.run()`, `.run_unit()` and `.run_result()` to the Input trait. This fixes #96. That issue doesn't mention `run_unit` and `run_result`, but I think those are necessary.
