### PR TITLE
Disable tests that write invalid utf-8 to stdout or stderr on windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -552,6 +552,7 @@ mod tests {
             }
 
             #[test]
+            #[cfg(not(windows))]
             fn invalid_utf8_to_stdout_is_allowed_when_not_captured() {
                 cmd_unit!(test_helper(), "invalid utf-8 stdout");
             }
@@ -989,6 +990,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg(not(windows))]
         fn does_allow_invalid_utf_8_to_stderr_when_not_captured() {
             cmd_unit!(test_helper(), "invalid utf-8 stderr");
         }


### PR DESCRIPTION
According to https://doc.rust-lang.org/std/io/struct.Stderr.html#note-windows-portability-consideration these tests shouldn't work on windows. They also didn't work in my tests. They _did_ work on github ci, and I don't know why. In any case I'm disabling these tests on windows.