### PR TITLE
Fix CI builds for new versions of dependencies from crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ version = "1.0.0"
 optional = true
 
 [target.'cfg(unix)'.dependencies.nix]
-version = "=0.21.0"
+version = "0.21.0"
 optional = true
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [".", "memory-tests"]
 rustversion = "1.0.4"
 
 [dev-dependencies]
+bitflags = "=1.2.1"
 executable-path = "1.0.0"
 lazy_static = "1.4.0"
 pretty_assertions = "0.7.2"
@@ -47,7 +48,7 @@ version = "1.0.0"
 optional = true
 
 [target.'cfg(unix)'.dependencies.nix]
-version = "0.21.0"
+version = "=0.21.0"
 optional = true
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,6 +420,7 @@ mod tests {
         env::{current_dir, set_current_dir},
         ffi::{OsStr, OsString},
         fs,
+        io::Write,
         path::PathBuf,
         sync::{Arc, Mutex},
     };
@@ -447,7 +448,18 @@ mod tests {
         lazy_static! {
             static ref BUILT: Arc<Mutex<BTreeSet<String>>> = Arc::new(Mutex::new(BTreeSet::new()));
         }
-        let mut set = BUILT.lock().unwrap();
+        let mut set = match BUILT.lock() {
+            Ok(set) => set,
+            Err(error) => {
+                let _ = write!(
+                    std::io::stderr(),
+                    "test_executable: BUILT poisoned: {}",
+                    error
+                );
+                let _ = std::io::stderr().flush();
+                std::process::exit(1)
+            }
+        };
         if !set.contains(name) {
             set.insert(name.to_owned());
             cmd_unit!(


### PR DESCRIPTION
There's a weird problem caused be the newly released `bitflags-1.3.1` on CI on older rustcs. This causes `cargo build --bin test_executables_helper --features test_executables` to fail. Unfortunately we only execute that command from within the test-suite. And if it fails, the test-suite hangs. :( This PR makes the test-suite crash when this happens.

Edit: point to bitflags instead of libc.