### PR TITLE
Rename main macros and Input methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Here's an example:
 use cradle::prelude::*;
 
 fn main() {
-    let StdoutTrimmed(git_version) = run_output!(%"git --version");
-    eprintln!("git version: {}", git_version);
+    // output git version
+    run!(%"git --version");
+    // output configured git user
     let (StdoutTrimmed(git_user), Status(status)) = run_output!(%"git config --get user.name");
     if status.success() {
         eprintln!("git user: {}", git_user);

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Here's an example:
 use cradle::prelude::*;
 
 fn main() {
-    let StdoutTrimmed(git_version) = cmd!(%"git --version");
+    let StdoutTrimmed(git_version) = run_output!(%"git --version");
     eprintln!("git version: {}", git_version);
-    let (StdoutTrimmed(git_user), Status(status)) = cmd!(%"git config --get user.name");
+    let (StdoutTrimmed(git_user), Status(status)) = run_output!(%"git config --get user.name");
     if status.success() {
         eprintln!("git user: {}", git_user);
     } else {

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -1,8 +1,9 @@
 use cradle::prelude::*;
 
 fn main() {
-    let StdoutTrimmed(git_version) = run_output!(%"git --version");
-    eprintln!("git version: {}", git_version);
+    // output git version
+    run!(%"git --version");
+    // output configured git user
     let (StdoutTrimmed(git_user), Status(status)) = run_output!(%"git config --get user.name");
     if status.success() {
         eprintln!("git user: {}", git_user);

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -1,9 +1,9 @@
 use cradle::prelude::*;
 
 fn main() {
-    let StdoutTrimmed(git_version) = cmd!(%"git --version");
+    let StdoutTrimmed(git_version) = run_output!(%"git --version");
     eprintln!("git version: {}", git_version);
-    let (StdoutTrimmed(git_user), Status(status)) = cmd!(%"git config --get user.name");
+    let (StdoutTrimmed(git_user), Status(status)) = run_output!(%"git config --get user.name");
     if status.success() {
         eprintln!("git user: {}", git_user);
     } else {

--- a/memory-tests/src/bin/cradle_user.rs
+++ b/memory-tests/src/bin/cradle_user.rs
@@ -5,7 +5,7 @@ fn main() {
     let stream_type: String = args.nth(1).unwrap();
     let bytes: usize = args.next().unwrap().parse().unwrap();
     eprintln!("consuming {} KiB", bytes / 2_usize.pow(10));
-    cmd_unit!(
+    run!(
         "./target/release/produce_bytes",
         stream_type,
         bytes.to_string()

--- a/src/child_output.rs
+++ b/src/child_output.rs
@@ -10,13 +10,13 @@ use std::{
 
 #[doc(hidden)]
 #[derive(Clone, Debug)]
-pub struct RunResult {
+pub struct ChildOutput {
     pub(crate) stdout: Option<Vec<u8>>,
     pub(crate) stderr: Option<Vec<u8>>,
     pub(crate) exit_status: ExitStatus,
 }
 
-impl RunResult {
+impl ChildOutput {
     pub fn run_child_process_output<Stdout, Stderr, T>(
         context: Context<Stdout, Stderr>,
         mut config: Config,
@@ -27,7 +27,7 @@ impl RunResult {
         T: Output,
     {
         <T as Output>::configure(&mut config);
-        let result = RunResult::run_child_process(context, &config);
+        let result = ChildOutput::run_child_process(context, &config);
         T::from_run_result(&config, result)
     }
 

--- a/src/context_integration_tests.rs
+++ b/src/context_integration_tests.rs
@@ -3,7 +3,7 @@ fn main() {
     {
         {
             use cradle::prelude::*;
-            cmd_unit!(
+            run!(
                 LogCommand,
                 %"cargo build --bin test_executables_helper --features test_executables",
             );

--- a/src/context_integration_tests.rs
+++ b/src/context_integration_tests.rs
@@ -27,14 +27,14 @@ fn main() {
 
         {
             assert_eq!(
-                with_gag(BufferRedirect::stdout, || cmd!(%"echo foo")),
+                with_gag(BufferRedirect::stdout, || run_output!(%"echo foo")),
                 "foo\n"
             );
         }
 
         {
             assert_eq!(
-                with_gag(BufferRedirect::stderr, || cmd!(
+                with_gag(BufferRedirect::stderr, || run_output!(
                     executable_path("test_executables_helper").to_str().unwrap(),
                     "write to stderr"
                 )),

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,7 +55,7 @@ impl Error {
 pub fn panic_on_error<T>(result: Result<T, Error>) -> T {
     match result {
         Ok(t) => t,
-        Err(error) => panic!("cmd!: {}", error),
+        Err(error) => panic!("run_output!: {}", error),
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-//! The [`Error`] type used in the return type of [`cmd_result!`].
+//! The [`Error`] type used in the return type of [`run_result!`].
 
 use crate::config::Config;
 use std::{ffi::OsString, fmt::Display, io, process::ExitStatus, string::FromUtf8Error, sync::Arc};
@@ -173,7 +173,7 @@ mod tests {
 
     #[test]
     fn invalid_utf8_to_stdout_has_source() {
-        let result: Result<StdoutUntrimmed, crate::Error> = cmd_result!(
+        let result: Result<StdoutUntrimmed, crate::Error> = run_result!(
             executable_path("cradle_test_helper").to_str().unwrap(),
             "invalid utf-8 stdout"
         );
@@ -182,7 +182,7 @@ mod tests {
 
     #[test]
     fn invalid_utf8_to_stderr_has_source() {
-        let result: Result<Stderr, crate::Error> = cmd_result!(
+        let result: Result<Stderr, crate::Error> = run_result!(
             executable_path("cradle_test_helper").to_str().unwrap(),
             "invalid utf-8 stderr"
         );

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,7 +55,7 @@ impl Error {
 pub fn panic_on_error<T>(result: Result<T, Error>) -> T {
     match result {
         Ok(t) => t,
-        Err(error) => panic!("run_output!: {}", error),
+        Err(error) => panic!("cradle error: {}", error),
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,4 +1,4 @@
-//! The [`Input`] trait that defines all possible inputs to `cradle`.
+//! The [`Input`] trait that defines all possible inputs to a child process.
 
 use crate::{config::Config, output::Output};
 use std::{

--- a/src/input.rs
+++ b/src/input.rs
@@ -93,23 +93,6 @@ pub trait Input {
     #[doc(hidden)]
     fn configure(self, config: &mut Config);
 
-    /// `input.run()` runs `input` as a child process.
-    /// It's equivalent to `cmd!(input)`.
-    ///
-    /// ```
-    /// use cradle::prelude::*;
-    ///
-    /// let StdoutTrimmed(output) = ("echo", "foo").run();
-    /// assert_eq!(output, "foo");
-    /// ```
-    fn run<O>(self) -> O
-    where
-        Self: Sized,
-        O: Output,
-    {
-        crate::cmd!(self)
-    }
-
     /// `input.run_unit()` runs `input` as a child process.
     /// It's equivalent to `cmd_unit!(input)`.
     ///
@@ -125,6 +108,23 @@ pub trait Input {
         Self: Sized,
     {
         crate::cmd_unit!(self);
+    }
+
+    /// `input.run()` runs `input` as a child process.
+    /// It's equivalent to `cmd!(input)`.
+    ///
+    /// ```
+    /// use cradle::prelude::*;
+    ///
+    /// let StdoutTrimmed(output) = ("echo", "foo").run();
+    /// assert_eq!(output, "foo");
+    /// ```
+    fn run<O>(self) -> O
+    where
+        Self: Sized,
+        O: Output,
+    {
+        crate::cmd!(self)
     }
 
     /// `input.run_result()` runs `input` as a child process.

--- a/src/input.rs
+++ b/src/input.rs
@@ -93,7 +93,7 @@ pub trait Input {
     #[doc(hidden)]
     fn configure(self, config: &mut Config);
 
-    /// `input.run_unit()` runs `input` as a child process.
+    /// `input.run()` runs `input` as a child process.
     /// It's equivalent to `run!(input)`.
     ///
     /// ```
@@ -101,9 +101,9 @@ pub trait Input {
     /// # std::env::set_current_dir(&temp_dir).unwrap();
     /// use cradle::prelude::*;
     ///
-    /// ("touch", "foo").run_unit();
+    /// ("touch", "foo").run();
     /// ```
-    fn run_unit(self)
+    fn run(self)
     where
         Self: Sized,
     {

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,4 +1,4 @@
-//! The [`Input`] trait that defines all possible inputs to [`cmd!`],
+//! The [`Input`] trait that defines all possible inputs to [`run_output!`],
 //! [`run!`] and [`cmd_result!`].
 
 use crate::{config::Config, output::Output};
@@ -8,7 +8,7 @@ use std::{
     sync::Arc,
 };
 
-/// All types that are possible arguments to [`cmd!`], [`run!`] or
+/// All types that are possible arguments to [`run_output!`], [`run!`] or
 /// [`cmd_result!`] must implement this trait.
 /// This makes `cradle` very flexible.
 /// For example you can pass in an executable as a String,
@@ -19,7 +19,7 @@ use std::{
 ///
 /// let executable = "echo";
 /// let arguments = vec!["foo", "bar"];
-/// let StdoutUntrimmed(output) = cmd!(executable, arguments);
+/// let StdoutUntrimmed(output) = run_output!(executable, arguments);
 /// assert_eq!(output, "foo bar\n");
 /// ```
 ///
@@ -47,13 +47,13 @@ use std::{
 /// ## Tuples
 ///
 /// `cradle` also implements [`Input`] for tuples of types that themselves implement [`Input`].
-/// Instead of passing multiple arguments to [`cmd!`], they can be passed in a single tuple:
+/// Instead of passing multiple arguments to [`run_output!`], they can be passed in a single tuple:
 ///
 /// ```
 /// use cradle::prelude::*;
 ///
 /// let args = ("echo", "foo");
-/// let StdoutTrimmed(output) = cmd!(args);
+/// let StdoutTrimmed(output) = run_output!(args);
 /// assert_eq!(output, "foo");
 /// ```
 ///
@@ -63,17 +63,17 @@ use std::{
 /// use cradle::prelude::*;
 ///
 /// let to_hex_command = ("xxd", "-ps", "-u", LogCommand);
-/// let StdoutTrimmed(output) = cmd!(to_hex_command, Stdin(&[14, 15, 16]));
+/// let StdoutTrimmed(output) = run_output!(to_hex_command, Stdin(&[14, 15, 16]));
 /// assert_eq!(output, "0E0F10");
 /// ```
 ///
-/// Also, tuples make it possible to write wrappers around [`cmd!`] without requiring the use of macros:
+/// Also, tuples make it possible to write wrappers around [`run_output!`] without requiring the use of macros:
 ///
 /// ```
 /// use cradle::prelude::*;
 ///
 /// fn to_hex<I: Input>(input: I) -> String {
-///   let StdoutTrimmed(hex) = cmd!(%"xxd -ps -u", input);
+///   let StdoutTrimmed(hex) = run_output!(%"xxd -ps -u", input);
 ///   hex
 /// }
 ///
@@ -111,7 +111,7 @@ pub trait Input {
     }
 
     /// `input.run()` runs `input` as a child process.
-    /// It's equivalent to `cmd!(input)`.
+    /// It's equivalent to `run_output!(input)`.
     ///
     /// ```
     /// use cradle::prelude::*;
@@ -124,7 +124,7 @@ pub trait Input {
         Self: Sized,
         O: Output,
     {
-        crate::cmd!(self)
+        crate::run_output!(self)
     }
 
     /// `input.run_result()` runs `input` as a child process.
@@ -200,7 +200,7 @@ impl Input for &OsStr {
 /// ```
 /// use cradle::prelude::*;
 ///
-/// let StdoutTrimmed(output) = cmd!("echo", "foo");
+/// let StdoutTrimmed(output) = run_output!("echo", "foo");
 /// assert_eq!(output, "foo");
 /// ```
 impl Input for &str {
@@ -218,7 +218,7 @@ impl Input for &str {
 ///
 /// let executable: String = "echo".to_string();
 /// let argument: String = "foo".to_string();
-/// let StdoutTrimmed(output) = cmd!(executable, argument);
+/// let StdoutTrimmed(output) = run_output!(executable, argument);
 /// assert_eq!(output, "foo");
 /// ```
 impl Input for String {
@@ -234,10 +234,10 @@ impl Input for String {
 /// ```
 /// use cradle::prelude::*;
 ///
-/// let StdoutTrimmed(output) = cmd!(Split("echo foo"));
+/// let StdoutTrimmed(output) = run_output!(Split("echo foo"));
 /// assert_eq!(output, "foo");
 ///
-/// let StdoutTrimmed(output) = cmd!(Split(format!("echo {}", 100)));
+/// let StdoutTrimmed(output) = run_output!(Split(format!("echo {}", 100)));
 /// assert_eq!(output, "100");
 /// ```
 ///
@@ -247,7 +247,7 @@ impl Input for String {
 /// ```
 /// use cradle::prelude::*;
 ///
-/// let StdoutTrimmed(output) = cmd!(%"echo foo");
+/// let StdoutTrimmed(output) = run_output!(%"echo foo");
 /// assert_eq!(output, "foo");
 /// ```
 ///
@@ -269,7 +269,7 @@ impl<T: AsRef<str>> Input for crate::input::Split<T> {
 /// ```
 /// use cradle::prelude::*;
 ///
-/// let StdoutTrimmed(output) = cmd!("echo foo".split(' '));
+/// let StdoutTrimmed(output) = run_output!("echo foo".split(' '));
 /// assert_eq!(output, "foo");
 /// ```
 ///
@@ -290,7 +290,7 @@ impl<'a> Input for std::str::Split<'a, char> {
 /// ```
 /// use cradle::prelude::*;
 ///
-/// let StdoutTrimmed(output) = cmd!("echo foo".split_whitespace());
+/// let StdoutTrimmed(output) = run_output!("echo foo".split_whitespace());
 /// assert_eq!(output, "foo");
 /// ```
 ///
@@ -309,7 +309,7 @@ impl<'a> Input for std::str::SplitWhitespace<'a> {
 /// ```
 /// use cradle::prelude::*;
 ///
-/// let StdoutTrimmed(output) = cmd!("echo foo".split_ascii_whitespace());
+/// let StdoutTrimmed(output) = run_output!("echo foo".split_ascii_whitespace());
 /// assert_eq!(output, "foo");
 /// ```
 ///
@@ -350,13 +350,13 @@ tuple_impl!(0, A, 1, B, 2, C, 3, D, 4, E,);
 tuple_impl!(0, A, 1, B, 2, C, 3, D, 4, E, 5, F,);
 tuple_impl!(0, A, 1, B, 2, C, 3, D, 4, E, 5, F, 6, G,);
 
-/// All elements of the given [`Vec`] are used as arguments to [`cmd!`].
+/// All elements of the given [`Vec`] are used as arguments to [`run_output!`].
 /// Same as passing in the elements separately.
 ///
 /// ```
 /// use cradle::prelude::*;
 ///
-/// let StdoutTrimmed(output) = cmd!(vec!["echo", "foo"]);
+/// let StdoutTrimmed(output) = run_output!(vec!["echo", "foo"]);
 /// assert_eq!(output, "foo");
 /// ```
 impl<T> Input for Vec<T>
@@ -377,7 +377,7 @@ where
 /// ```
 /// use cradle::prelude::*;
 ///
-/// let StdoutTrimmed(output) = cmd!(["echo", "foo"]);
+/// let StdoutTrimmed(output) = run_output!(["echo", "foo"]);
 /// assert_eq!(output, "foo");
 /// ```
 ///
@@ -407,7 +407,7 @@ where
     }
 }
 
-/// Passing in [`LogCommand`] as an argument to [`cmd!`] will cause it
+/// Passing in [`LogCommand`] as an argument to [`run_output!`] will cause it
 /// to log the commands (including all arguments) to `stderr`.
 /// (This is similar `bash`'s `-x` option.)
 ///
@@ -435,7 +435,7 @@ impl Input for LogCommand {
 ///
 /// # #[cfg(linux)]
 /// # {
-/// let StdoutTrimmed(output) = cmd!("pwd", CurrentDir("/tmp"));
+/// let StdoutTrimmed(output) = run_output!("pwd", CurrentDir("/tmp"));
 /// assert_eq!(output, "/tmp");
 /// # }
 /// ```
@@ -499,7 +499,7 @@ impl Input for &Path {
 ///
 /// # #[cfg(linux)]
 /// # {
-/// let StdoutUntrimmed(output) = cmd!("sort", Stdin("foo\nbar\n"));
+/// let StdoutUntrimmed(output) = run_output!("sort", Stdin("foo\nbar\n"));
 /// assert_eq!(output, "bar\nfoo\n");
 /// # }
 /// ```
@@ -524,7 +524,7 @@ where
 /// ```
 /// use cradle::prelude::*;
 ///
-/// let StdoutUntrimmed(output) = cmd!("env", Env("FOO", "bar"));
+/// let StdoutUntrimmed(output) = run_output!("env", Env("FOO", "bar"));
 /// assert!(output.contains("FOO=bar\n"));
 /// ```
 ///

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,5 @@
 //! The [`Input`] trait that defines all possible inputs to [`run_output!`],
-//! [`run!`] and [`cmd_result!`].
+//! [`run!`] and [`run_result!`].
 
 use crate::{config::Config, output::Output};
 use std::{
@@ -9,7 +9,7 @@ use std::{
 };
 
 /// All types that are possible arguments to [`run_output!`], [`run!`] or
-/// [`cmd_result!`] must implement this trait.
+/// [`run_result!`] must implement this trait.
 /// This makes `cradle` very flexible.
 /// For example you can pass in an executable as a String,
 /// and a variable number of arguments as a [`Vec`]:
@@ -128,17 +128,17 @@ pub trait Input {
     }
 
     /// `input.run_result()` runs `input` as a child process.
-    /// It's equivalent to `cmd_result!(input)`.
+    /// It's equivalent to `run_result!(input)`.
     ///
     /// ```
     /// use cradle::prelude::*;
     ///
     /// # fn build() -> Result<(), Error> {
     /// // make sure build tools are installed
-    /// cmd_result!(%"which make")?;
-    /// cmd_result!(%"which gcc")?;
-    /// cmd_result!(%"which ld")?;
-    /// cmd_result!(%"make build")?;
+    /// run_result!(%"which make")?;
+    /// run_result!(%"which gcc")?;
+    /// run_result!(%"which ld")?;
+    /// run_result!(%"make build")?;
     /// # Ok(())
     /// # }
     /// ```
@@ -147,7 +147,7 @@ pub trait Input {
         Self: Sized,
         O: Output,
     {
-        crate::cmd_result!(self)
+        crate::run_result!(self)
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -116,10 +116,10 @@ pub trait Input {
     /// ```
     /// use cradle::prelude::*;
     ///
-    /// let StdoutTrimmed(output) = ("echo", "foo").run();
+    /// let StdoutTrimmed(output) = ("echo", "foo").run_output();
     /// assert_eq!(output, "foo");
     /// ```
-    fn run<O>(self) -> O
+    fn run_output<O>(self) -> O
     where
         Self: Sized,
         O: Output,

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,5 @@
 //! The [`Input`] trait that defines all possible inputs to [`cmd!`],
-//! [`cmd_unit!`] and [`cmd_result!`].
+//! [`run!`] and [`cmd_result!`].
 
 use crate::{config::Config, output::Output};
 use std::{
@@ -8,7 +8,7 @@ use std::{
     sync::Arc,
 };
 
-/// All types that are possible arguments to [`cmd!`], [`cmd_unit!`] or
+/// All types that are possible arguments to [`cmd!`], [`run!`] or
 /// [`cmd_result!`] must implement this trait.
 /// This makes `cradle` very flexible.
 /// For example you can pass in an executable as a String,
@@ -94,7 +94,7 @@ pub trait Input {
     fn configure(self, config: &mut Config);
 
     /// `input.run_unit()` runs `input` as a child process.
-    /// It's equivalent to `cmd_unit!(input)`.
+    /// It's equivalent to `run!(input)`.
     ///
     /// ```
     /// # let temp_dir = tempfile::TempDir::new().unwrap();
@@ -107,7 +107,7 @@ pub trait Input {
     where
         Self: Sized,
     {
-        crate::cmd_unit!(self);
+        crate::run!(self);
     }
 
     /// `input.run()` runs `input` as a child process.
@@ -168,7 +168,7 @@ where
 /// ```
 /// use cradle::prelude::*;
 ///
-/// cmd_unit!("ls", std::env::var_os("HOME").unwrap());
+/// run!("ls", std::env::var_os("HOME").unwrap());
 /// ```
 impl Input for OsString {
     #[doc(hidden)]
@@ -183,7 +183,7 @@ impl Input for OsString {
 /// ```
 /// use cradle::prelude::*;
 ///
-/// cmd_unit!("echo", std::env::current_dir().unwrap().file_name().unwrap());
+/// run!("echo", std::env::current_dir().unwrap().file_name().unwrap());
 /// ```
 ///
 /// [`&OsStr`]: std::ffi::OsStr
@@ -414,7 +414,7 @@ where
 /// ```
 /// use cradle::prelude::*;
 ///
-/// cmd_unit!(LogCommand, %"echo foo");
+/// run!(LogCommand, %"echo foo");
 /// // writes '+ echo foo' to stderr
 /// ```
 #[derive(Clone, Debug)]
@@ -462,7 +462,7 @@ where
 /// use std::path::PathBuf;
 ///
 /// let current_dir: PathBuf = std::env::current_dir().unwrap();
-/// cmd_unit!("ls", current_dir);
+/// run!("ls", current_dir);
 /// ```
 impl Input for PathBuf {
     #[doc(hidden)]
@@ -481,7 +481,7 @@ impl Input for PathBuf {
 /// use std::path::Path;
 ///
 /// let file: &Path = Path::new("./foo");
-/// cmd_unit!("touch", file);
+/// run!("touch", file);
 /// ```
 ///
 /// [`&Path`]: std::path::Path

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,4 @@
-//! The [`Input`] trait that defines all possible inputs to [`run_output!`],
-//! [`run!`] and [`run_result!`].
+//! The [`Input`] trait that defines all possible inputs to `cradle`.
 
 use crate::{config::Config, output::Output};
 use std::{
@@ -8,7 +7,7 @@ use std::{
     sync::Arc,
 };
 
-/// All types that are possible arguments to [`run_output!`], [`run!`] or
+/// All types that are possible arguments to [`run!`], [`run_output!`] or
 /// [`run_result!`] must implement this trait.
 /// This makes `cradle` very flexible.
 /// For example you can pass in an executable as a String,
@@ -47,7 +46,7 @@ use std::{
 /// ## Tuples
 ///
 /// `cradle` also implements [`Input`] for tuples of types that themselves implement [`Input`].
-/// Instead of passing multiple arguments to [`run_output!`], they can be passed in a single tuple:
+/// Instead of passing multiple arguments to [`run!`], they can be passed in a single tuple:
 ///
 /// ```
 /// use cradle::prelude::*;
@@ -67,7 +66,7 @@ use std::{
 /// assert_eq!(output, "0E0F10");
 /// ```
 ///
-/// Also, tuples make it possible to write wrappers around [`run_output!`] without requiring the use of macros:
+/// Also, tuples make it possible to write wrappers around [`run!`] without requiring the use of macros:
 ///
 /// ```
 /// use cradle::prelude::*;
@@ -350,7 +349,7 @@ tuple_impl!(0, A, 1, B, 2, C, 3, D, 4, E,);
 tuple_impl!(0, A, 1, B, 2, C, 3, D, 4, E, 5, F,);
 tuple_impl!(0, A, 1, B, 2, C, 3, D, 4, E, 5, F, 6, G,);
 
-/// All elements of the given [`Vec`] are used as arguments to [`run_output!`].
+/// All elements of the given [`Vec`] are used as arguments to the child process.
 /// Same as passing in the elements separately.
 ///
 /// ```
@@ -407,7 +406,7 @@ where
     }
 }
 
-/// Passing in [`LogCommand`] as an argument to [`run_output!`] will cause it
+/// Passing in [`LogCommand`] as an argument to `cradle` will cause it
 /// to log the commands (including all arguments) to `stderr`.
 /// (This is similar `bash`'s `-x` option.)
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,7 +304,7 @@ mod tests {
     macro_rules! cmd_result_with_context_unit {
         ($context:expr, $($args:tt)*) => {{
             let result: std::result::Result<(), $crate::Error> =
-              $crate::cmd_result_with_context!($context, $($args)*);
+              $crate::run_result_with_context!($context, $($args)*);
             result
         }}
     }
@@ -600,7 +600,7 @@ mod tests {
             let context = Context::test();
             let config: Vec<LogCommand> = vec![LogCommand];
             let StdoutTrimmed(stdout) =
-                crate::cmd_result_with_context!(context.clone(), config, %"echo foo").unwrap();
+                crate::run_result_with_context!(context.clone(), config, %"echo foo").unwrap();
             assert_eq!(stdout, "foo");
             assert_eq!(context.stderr(), "+ echo foo\n");
         }
@@ -619,7 +619,7 @@ mod tests {
             let context = Context::test();
             let config: [LogCommand; 1] = [LogCommand];
             let StdoutTrimmed(stdout) =
-                crate::cmd_result_with_context!(context.clone(), config, %"echo foo").unwrap();
+                crate::run_result_with_context!(context.clone(), config, %"echo foo").unwrap();
             assert_eq!(stdout, "foo");
             assert_eq!(context.stderr(), "+ echo foo\n");
         }
@@ -664,7 +664,7 @@ mod tests {
             let context = Context::test();
             let config: &[LogCommand] = &[LogCommand];
             let StdoutTrimmed(stdout) =
-                crate::cmd_result_with_context!(context.clone(), config, %"echo foo").unwrap();
+                crate::run_result_with_context!(context.clone(), config, %"echo foo").unwrap();
             assert_eq!(stdout, "foo");
             assert_eq!(context.stderr(), "+ echo foo\n");
         }
@@ -747,7 +747,7 @@ mod tests {
         #[test]
         fn relays_stdout_for_non_zero_exit_codes() {
             let context = Context::test();
-            let _: Result<(), Error> = crate::cmd_result_with_context!(
+            let _: Result<(), Error> = crate::run_result_with_context!(
                 context.clone(),
                 test_helper(),
                 "output foo and exit with 42"
@@ -780,7 +780,7 @@ mod tests {
         fn does_not_relay_stdout_when_collecting_into_string() {
             let context = Context::test();
             let StdoutTrimmed(_) =
-                crate::cmd_result_with_context!(context.clone(), %"echo foo").unwrap();
+                crate::run_result_with_context!(context.clone(), %"echo foo").unwrap();
             assert_eq!(context.stdout(), "");
         }
 
@@ -788,7 +788,7 @@ mod tests {
         fn does_not_relay_stdout_when_collecting_into_result_of_string() {
             let context = Context::test();
             let _: Result<StdoutTrimmed, Error> =
-                crate::cmd_result_with_context!(context.clone(), %"echo foo");
+                crate::run_result_with_context!(context.clone(), %"echo foo");
             assert_eq!(context.stdout(), "");
         }
     }
@@ -809,7 +809,7 @@ mod tests {
         #[test]
         fn relays_stderr_for_non_zero_exit_codes() {
             let context = Context::test();
-            let _: Result<(), Error> = crate::cmd_result_with_context!(
+            let _: Result<(), Error> = crate::run_result_with_context!(
                 context.clone(),
                 test_helper(),
                 "write to stderr and exit with 42"
@@ -877,7 +877,7 @@ mod tests {
         fn does_not_relay_stderr_when_catpuring() {
             let context = Context::test();
             let Stderr(_) =
-                crate::cmd_result_with_context!(context.clone(), test_helper(), "write to stderr")
+                crate::run_result_with_context!(context.clone(), test_helper(), "write to stderr")
                     .unwrap();
             assert_eq!(context.stderr(), "");
         }
@@ -1133,7 +1133,7 @@ mod tests {
             fn does_not_relay_stdout() {
                 let context = Context::test();
                 let StdoutTrimmed(_) =
-                    crate::cmd_result_with_context!(context.clone(), %"echo foo").unwrap();
+                    crate::run_result_with_context!(context.clone(), %"echo foo").unwrap();
                 assert_eq!(context.stdout(), "");
             }
         }
@@ -1157,7 +1157,7 @@ mod tests {
             fn does_not_relay_stdout() {
                 let context = Context::test();
                 let StdoutUntrimmed(_) =
-                    crate::cmd_result_with_context!(context.clone(), %"echo foo").unwrap();
+                    crate::run_result_with_context!(context.clone(), %"echo foo").unwrap();
                 assert_eq!(context.stdout(), "");
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,19 +334,19 @@ mod tests {
             use super::*;
 
             #[test]
-            #[should_panic(expected = "run_output!: false:\n  exited with exit code: 1")]
+            #[should_panic(expected = "cradle error: false:\n  exited with exit code: 1")]
             fn non_zero_exit_codes() {
                 run!("false");
             }
 
             #[test]
-            #[should_panic(expected = "run_output!: false:\n  exited with exit code: 1")]
+            #[should_panic(expected = "cradle error: false:\n  exited with exit code: 1")]
             fn combine_panics_with_other_outputs() {
                 let StdoutTrimmed(_) = run_output!("false");
             }
 
             #[test]
-            #[should_panic(expected = "run_output!: false foo bar:\n  exited with exit code: 1")]
+            #[should_panic(expected = "cradle error: false foo bar:\n  exited with exit code: 1")]
             fn includes_full_command_on_non_zero_exit_codes() {
                 run!(%"false foo bar");
             }
@@ -359,7 +359,7 @@ mod tests {
 
             #[test]
             #[should_panic(
-                expected = "run_output!: File not found error when executing 'does-not-exist'"
+                expected = "cradle error: File not found error when executing 'does-not-exist'"
             )]
             fn executable_cannot_be_found() {
                 run!("does-not-exist");
@@ -390,7 +390,7 @@ mod tests {
             }
 
             #[test]
-            #[should_panic(expected = "run_output!: no arguments given")]
+            #[should_panic(expected = "cradle error: no arguments given")]
             fn no_executable() {
                 let vector: Vec<String> = Vec::new();
                 run!(vector);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,30 +4,30 @@
 //! APIs may change drastically!
 //! Use at your own risk!)
 //!
-//! `cradle` provides the [`cmd!`] macro, that makes
+//! `cradle` provides the [`run_output!`] macro, that makes
 //! it easy to run child processes from rust programs.
 //!
 //! ```
 //! use cradle::prelude::*;
 //!
-//! let StdoutTrimmed(stdout) = cmd!(%"echo foo");
+//! let StdoutTrimmed(stdout) = run_output!(%"echo foo");
 //! assert_eq!(stdout, "foo");
 //! ```
 //!
 //! # Arguments
 //!
-//! You can pass in multiple arguments (of different types) to [`cmd!`]
+//! You can pass in multiple arguments (of different types) to [`run_output!`]
 //! to specify arguments, as long as they implement the [`Input`](input::Input)
 //! trait:
 //!
 //! ```
 //! use cradle::prelude::*;
 //!
-//! let StdoutTrimmed(stdout) = cmd!("echo", "foo", "bar");
+//! let StdoutTrimmed(stdout) = run_output!("echo", "foo", "bar");
 //! assert_eq!(stdout, "foo bar");
 //! ```
 //!
-//! For all possible inputs to [`cmd!`], see the documentation of [`Input`](input::Input).
+//! For all possible inputs to [`run_output!`], see the documentation of [`Input`](input::Input).
 //!
 //! ## Whitespace Splitting
 //!
@@ -37,7 +37,7 @@
 //! ``` should_panic
 //! use cradle::prelude::*;
 //!
-//! let StdoutTrimmed(_) = cmd!("echo foo");
+//! let StdoutTrimmed(_) = run_output!("echo foo");
 //! ```
 //!
 //! In this code `cradle` tries to run a process from an executable called
@@ -48,13 +48,13 @@
 //! ```
 //! use cradle::prelude::*;
 //!
-//! let StdoutTrimmed(output) = cmd!(Split("echo foo"));
+//! let StdoutTrimmed(output) = run_output!(Split("echo foo"));
 //! assert_eq!(output, "foo");
 //! ```
 //!
 //! Wrapping an argument of type `&str` in [`Split`](input::Split) will cause `cradle` to first
 //! split it by whitespace and then use the resulting words as if they were passed
-//! into [`cmd!`] as separate arguments.
+//! into [`run_output!`] as separate arguments.
 //!
 //! And -- since this is such a common case -- `cradle` provides a syntactic shortcut
 //! for [`Split`](input::Split), the `%` symbol:
@@ -62,13 +62,13 @@
 //! ```
 //! use cradle::prelude::*;
 //!
-//! let StdoutTrimmed(output) = cmd!(%"echo foo");
+//! let StdoutTrimmed(output) = run_output!(%"echo foo");
 //! assert_eq!(output, "foo");
 //! ```
 //!
 //! # Output
 //!
-//! You can choose which return type you want [`cmd!`] to return,
+//! You can choose which return type you want [`run_output!`] to return,
 //! as long as the chosen return type implements [`output::Output`].
 //! For example you can use e.g. [`StdoutTrimmed`](output::StdoutTrimmed)
 //! to collect what the child process writes to `stdout`,
@@ -77,14 +77,14 @@
 //! ```
 //! use cradle::prelude::*;
 //!
-//! let StdoutTrimmed(output) = cmd!(%"echo foo");
+//! let StdoutTrimmed(output) = run_output!(%"echo foo");
 //! assert_eq!(output, "foo");
 //! ```
 //!
 //! (By default, the child's `stdout` is written to the parent's `stdout`.
 //! Using `StdoutTrimmed` as the return type suppresses that.)
 //!
-//! If you don't want any result from [`cmd!`], you can use `()`
+//! If you don't want any result from [`run_output!`], you can use `()`
 //! as the return value:
 //!
 //! ```
@@ -92,11 +92,11 @@
 //! # std::env::set_current_dir(&temp_dir).unwrap();
 //! use cradle::prelude::*;
 //!
-//! let () = cmd!(%"touch foo");
+//! let () = run_output!(%"touch foo");
 //! ```
 //!
 //! Since that's a very common case, `cradle` provides the [`run!`] shortcut.
-//! It behaves exactly like [`cmd!`] but always returns `()`.
+//! It behaves exactly like [`run_output!`] but always returns `()`.
 //!
 //! ```
 //! # let temp_dir = tempfile::TempDir::new().unwrap();
@@ -110,11 +110,11 @@
 //!
 //! # Error Handling
 //!
-//! By default [`cmd!`] panics for a few reasons, e.g.:
+//! By default [`run_output!`] panics for a few reasons, e.g.:
 //!
 //! - when the child process exits with a non-zero exitcode,
 //! - when the given executable cannot be found,
-//! - when no strings are given as arguments to [`cmd!`].
+//! - when no strings are given as arguments to [`run_output!`].
 //!
 //! For example:
 //!
@@ -126,12 +126,12 @@
 //! ```
 //!
 //! You can suppress panics caused by non-zero exit codes by using the
-//! [`Status`](output::Status) type as a return type of [`cmd!`]:
+//! [`Status`](output::Status) type as a return type of [`run_output!`]:
 //!
 //! ```
 //! use cradle::prelude::*;
 //!
-//! let Status(exit_status) = cmd!("false");
+//! let Status(exit_status) = run_output!("false");
 //! assert_eq!(exit_status.code(), Some(1));
 //! ```
 //!
@@ -181,7 +181,7 @@
 //! [`Input`](input::Input).
 //! When using these methods, it's especially useful that
 //! [`Input`](input::Input) is implemented by tuples.
-//! They work analog to [`cmd!`], [`run!`] and [`cmd_result!`].
+//! They work analog to [`run_output!`], [`run!`] and [`cmd_result!`].
 //! Here are some examples:
 //!
 //! ```
@@ -324,19 +324,19 @@ mod tests {
             use super::*;
 
             #[test]
-            #[should_panic(expected = "cmd!: false:\n  exited with exit code: 1")]
+            #[should_panic(expected = "run_output!: false:\n  exited with exit code: 1")]
             fn non_zero_exit_codes() {
                 run!("false");
             }
 
             #[test]
-            #[should_panic(expected = "cmd!: false:\n  exited with exit code: 1")]
+            #[should_panic(expected = "run_output!: false:\n  exited with exit code: 1")]
             fn combine_panics_with_other_outputs() {
-                let StdoutTrimmed(_) = cmd!("false");
+                let StdoutTrimmed(_) = run_output!("false");
             }
 
             #[test]
-            #[should_panic(expected = "cmd!: false foo bar:\n  exited with exit code: 1")]
+            #[should_panic(expected = "run_output!: false foo bar:\n  exited with exit code: 1")]
             fn includes_full_command_on_non_zero_exit_codes() {
                 run!(%"false foo bar");
             }
@@ -348,7 +348,9 @@ mod tests {
             }
 
             #[test]
-            #[should_panic(expected = "cmd!: File not found error when executing 'does-not-exist'")]
+            #[should_panic(
+                expected = "run_output!: File not found error when executing 'does-not-exist'"
+            )]
             fn executable_cannot_be_found() {
                 run!("does-not-exist");
             }
@@ -366,7 +368,8 @@ mod tests {
             #[rustversion::since(1.46)]
             #[test]
             fn includes_source_location_of_cmd_call() {
-                let (Status(_), Stderr(stderr)) = cmd!(test_executable("test_executables_panic"));
+                let (Status(_), Stderr(stderr)) =
+                    run_output!(test_executable("test_executables_panic"));
                 let expected = "src/test_executables/panic.rs:4:5";
                 assert!(
                     stderr.contains(expected),
@@ -377,7 +380,7 @@ mod tests {
             }
 
             #[test]
-            #[should_panic(expected = "cmd!: no arguments given")]
+            #[should_panic(expected = "run_output!: no arguments given")]
             fn no_executable() {
                 let vector: Vec<String> = Vec::new();
                 run!(vector);
@@ -386,7 +389,7 @@ mod tests {
             #[test]
             #[should_panic(expected = "invalid utf-8 written to stdout")]
             fn invalid_utf8_stdout() {
-                let StdoutTrimmed(_) = cmd!(test_helper(), "invalid utf-8 stdout");
+                let StdoutTrimmed(_) = run_output!(test_helper(), "invalid utf-8 stdout");
             }
 
             #[test]
@@ -557,19 +560,19 @@ mod tests {
 
     #[test]
     fn allows_to_retrieve_stdout() {
-        let StdoutTrimmed(stdout) = cmd!(%"echo foo");
+        let StdoutTrimmed(stdout) = run_output!(%"echo foo");
         assert_eq!(stdout, "foo");
     }
 
     #[test]
     fn command_and_argument_as_separate_ref_str() {
-        let StdoutTrimmed(stdout) = cmd!("echo", "foo");
+        let StdoutTrimmed(stdout) = run_output!("echo", "foo");
         assert_eq!(stdout, "foo");
     }
 
     #[test]
     fn multiple_arguments_as_ref_str() {
-        let StdoutTrimmed(stdout) = cmd!("echo", "foo", "bar");
+        let StdoutTrimmed(stdout) = run_output!("echo", "foo", "bar");
         assert_eq!(stdout, "foo bar");
     }
 
@@ -578,7 +581,7 @@ mod tests {
         let reference: &LogCommand = &LogCommand;
         let executable: &String = &"echo".to_string();
         let argument: &String = &"foo".to_string();
-        let StdoutTrimmed(stdout) = cmd!(reference, executable, argument);
+        let StdoutTrimmed(stdout) = run_output!(reference, executable, argument);
         assert_eq!(stdout, "foo");
     }
 
@@ -588,7 +591,7 @@ mod tests {
         #[test]
         fn allows_to_pass_in_arguments_as_a_vec_of_ref_str() {
             let args: Vec<&str> = vec!["foo"];
-            let StdoutTrimmed(stdout) = cmd!("echo", args);
+            let StdoutTrimmed(stdout) = run_output!("echo", args);
             assert_eq!(stdout, "foo");
         }
 
@@ -606,7 +609,7 @@ mod tests {
         #[test]
         fn arrays_as_arguments() {
             let args: [&str; 2] = ["echo", "foo"];
-            let StdoutTrimmed(stdout) = cmd!(args);
+            let StdoutTrimmed(stdout) = run_output!(args);
             assert_eq!(stdout, "foo");
         }
 
@@ -635,7 +638,7 @@ mod tests {
         #[test]
         fn array_refs_as_arguments() {
             let args: &[&str; 2] = &["echo", "foo"];
-            let StdoutTrimmed(stdout) = cmd!(args);
+            let StdoutTrimmed(stdout) = run_output!(args);
             assert_eq!(stdout, "foo");
         }
 
@@ -652,7 +655,7 @@ mod tests {
         #[test]
         fn slices_as_arguments() {
             let args: &[&str] = &["echo", "foo"];
-            let StdoutTrimmed(stdout) = cmd!(args);
+            let StdoutTrimmed(stdout) = run_output!(args);
             assert_eq!(stdout, "foo");
         }
 
@@ -677,7 +680,7 @@ mod tests {
 
         #[test]
         fn vector_of_vectors() {
-            let StdoutTrimmed(output) = cmd!(vec![vec!["echo"], vec!["foo", "bar"]]);
+            let StdoutTrimmed(output) = run_output!(vec![vec!["echo"], vec!["foo", "bar"]]);
             assert_eq!(output, "foo bar");
         }
     }
@@ -695,14 +698,14 @@ mod tests {
         fn multiple_strings() {
             let command: String = "echo".to_string();
             let argument: String = "foo".to_string();
-            let StdoutTrimmed(output) = cmd!(command, argument);
+            let StdoutTrimmed(output) = run_output!(command, argument);
             assert_eq!(output, "foo");
         }
 
         #[test]
         fn mix_ref_str_and_string() {
             let argument: String = "foo".to_string();
-            let StdoutTrimmed(output) = cmd!("echo", argument);
+            let StdoutTrimmed(output) = run_output!("echo", argument);
             assert_eq!(output, "foo");
         }
 
@@ -848,7 +851,7 @@ mod tests {
 
         #[test]
         fn capture_stderr() {
-            let Stderr(stderr) = cmd!(test_helper(), "write to stderr");
+            let Stderr(stderr) = run_output!(test_helper(), "write to stderr");
             assert_eq!(stderr, "foo\n");
         }
 
@@ -935,19 +938,19 @@ mod tests {
 
         #[test]
         fn zero() {
-            let Status(exit_status) = cmd!("true");
+            let Status(exit_status) = run_output!("true");
             assert!(exit_status.success());
         }
 
         #[test]
         fn one() {
-            let Status(exit_status) = cmd!("false");
+            let Status(exit_status) = run_output!("false");
             assert!(!exit_status.success());
         }
 
         #[test]
         fn forty_two() {
-            let Status(exit_status) = cmd!(test_helper(), "exit code 42");
+            let Status(exit_status) = run_output!(test_helper(), "exit code 42");
             assert!(!exit_status.success());
             assert_eq!(exit_status.code(), Some(42));
         }
@@ -964,18 +967,18 @@ mod tests {
 
         #[test]
         fn success_exit_status_is_true() {
-            assert!(cmd!("true"));
+            assert!(run_output!("true"));
         }
 
         #[test]
         fn failure_exit_status_is_false() {
-            assert!(!cmd!("false"));
+            assert!(!run_output!("false"));
         }
 
         #[test]
         #[should_panic]
         fn io_error_panics() {
-            assert!(cmd!("/"));
+            assert!(run_output!("/"));
         }
     }
 
@@ -985,25 +988,25 @@ mod tests {
 
         #[test]
         fn two_tuple() {
-            let StdoutTrimmed(output) = cmd!(("echo", "foo"));
+            let StdoutTrimmed(output) = run_output!(("echo", "foo"));
             assert_eq!(output, "foo");
         }
 
         #[test]
         fn three_tuples() {
-            let StdoutTrimmed(output) = cmd!(("echo", "foo", "bar"));
+            let StdoutTrimmed(output) = run_output!(("echo", "foo", "bar"));
             assert_eq!(output, "foo bar");
         }
 
         #[test]
         fn nested_tuples() {
-            let StdoutTrimmed(output) = cmd!(("echo", ("foo", "bar")));
+            let StdoutTrimmed(output) = run_output!(("echo", ("foo", "bar")));
             assert_eq!(output, "foo bar");
         }
 
         #[test]
         fn unit_input() {
-            let StdoutTrimmed(output) = cmd!(("echo", ()));
+            let StdoutTrimmed(output) = run_output!(("echo", ()));
             assert_eq!(output, "");
         }
     }
@@ -1014,7 +1017,7 @@ mod tests {
         #[test]
         fn two_tuple_1() {
             let (StdoutTrimmed(output), Status(exit_status)) =
-                cmd!(test_helper(), "output foo and exit with 42");
+                run_output!(test_helper(), "output foo and exit with 42");
             assert_eq!(output, "foo");
             assert_eq!(exit_status.code(), Some(42));
         }
@@ -1022,7 +1025,7 @@ mod tests {
         #[test]
         fn two_tuple_2() {
             let (Status(exit_status), StdoutTrimmed(output)) =
-                cmd!(test_helper(), "output foo and exit with 42");
+                run_output!(test_helper(), "output foo and exit with 42");
             assert_eq!(output, "foo");
             assert_eq!(exit_status.code(), Some(42));
         }
@@ -1043,7 +1046,8 @@ mod tests {
 
         #[test]
         fn three_tuples() {
-            let (Stderr(stderr), StdoutTrimmed(stdout), Status(exit_status)) = cmd!(%"echo foo");
+            let (Stderr(stderr), StdoutTrimmed(stdout), Status(exit_status)) =
+                run_output!(%"echo foo");
             assert_eq!(stderr, "");
             assert_eq!(stdout, "foo");
             assert_eq!(exit_status.code(), Some(0));
@@ -1052,7 +1056,7 @@ mod tests {
         #[test]
         fn capturing_stdout_on_errors() {
             let (StdoutTrimmed(output), Status(exit_status)) =
-                cmd!(test_helper(), "output foo and exit with 42");
+                run_output!(test_helper(), "output foo and exit with 42");
             assert!(!exit_status.success());
             assert_eq!(output, "foo");
         }
@@ -1060,7 +1064,7 @@ mod tests {
         #[test]
         fn capturing_stderr_on_errors() {
             let (Stderr(output), Status(exit_status)) =
-                cmd!(test_helper(), "write to stderr and exit with 42");
+                run_output!(test_helper(), "write to stderr and exit with 42");
             assert!(!exit_status.success());
             assert_eq!(output, "foo\n");
         }
@@ -1076,7 +1080,7 @@ mod tests {
                 fs::create_dir("dir").unwrap();
                 fs::write("dir/file", "foo").unwrap();
                 fs::write("file", "wrong file").unwrap();
-                let StdoutUntrimmed(output) = cmd!(%"cat file", CurrentDir("dir"));
+                let StdoutUntrimmed(output) = run_output!(%"cat file", CurrentDir("dir"));
                 assert_eq!(output, "foo");
             });
         }
@@ -1103,25 +1107,25 @@ mod tests {
 
             #[test]
             fn trims_trailing_whitespace() {
-                let StdoutTrimmed(output) = cmd!(%"echo foo");
+                let StdoutTrimmed(output) = run_output!(%"echo foo");
                 assert_eq!(output, "foo");
             }
 
             #[test]
             fn trims_leading_whitespace() {
-                let StdoutTrimmed(output) = cmd!(%"echo -n", " foo");
+                let StdoutTrimmed(output) = run_output!(%"echo -n", " foo");
                 assert_eq!(output, "foo");
             }
 
             #[test]
             fn does_not_remove_whitespace_within_output() {
-                let StdoutTrimmed(output) = cmd!(%"echo -n", "foo bar");
+                let StdoutTrimmed(output) = run_output!(%"echo -n", "foo bar");
                 assert_eq!(output, "foo bar");
             }
 
             #[test]
             fn does_not_modify_output_without_whitespace() {
-                let StdoutTrimmed(output) = cmd!(%"echo -n", "foo");
+                let StdoutTrimmed(output) = run_output!(%"echo -n", "foo");
                 assert_eq!(output, "foo");
             }
 
@@ -1139,13 +1143,13 @@ mod tests {
 
             #[test]
             fn does_not_trim_trailing_newline() {
-                let StdoutUntrimmed(output) = cmd!(%"echo foo");
+                let StdoutUntrimmed(output) = run_output!(%"echo foo");
                 assert_eq!(output, "foo\n");
             }
 
             #[test]
             fn does_not_trim_leading_whitespace() {
-                let StdoutUntrimmed(output) = cmd!(%"echo -n", " foo");
+                let StdoutUntrimmed(output) = run_output!(%"echo -n", " foo");
                 assert_eq!(output, " foo");
             }
 
@@ -1164,31 +1168,31 @@ mod tests {
 
         #[test]
         fn splits_words_by_whitespace() {
-            let StdoutTrimmed(output) = cmd!(Split("echo foo"));
+            let StdoutTrimmed(output) = run_output!(Split("echo foo"));
             assert_eq!(output, "foo");
         }
 
         #[test]
         fn splits_owned_strings() {
-            let StdoutTrimmed(output) = cmd!(Split("echo foo".to_string()));
+            let StdoutTrimmed(output) = run_output!(Split("echo foo".to_string()));
             assert_eq!(output, "foo");
         }
 
         #[test]
         fn skips_multiple_whitespace_characters() {
-            let StdoutUntrimmed(output) = cmd!("echo", Split("foo  bar"));
+            let StdoutUntrimmed(output) = run_output!("echo", Split("foo  bar"));
             assert_eq!(output, "foo bar\n");
         }
 
         #[test]
         fn trims_leading_whitespace() {
-            let StdoutTrimmed(output) = cmd!(Split(" echo foo"));
+            let StdoutTrimmed(output) = run_output!(Split(" echo foo"));
             assert_eq!(output, "foo");
         }
 
         #[test]
         fn trims_trailing_whitespace() {
-            let StdoutUntrimmed(output) = cmd!("echo", Split("foo "));
+            let StdoutUntrimmed(output) = run_output!("echo", Split("foo "));
             assert_eq!(output, "foo\n");
         }
 
@@ -1197,26 +1201,26 @@ mod tests {
 
             #[test]
             fn splits_words() {
-                let StdoutUntrimmed(output) = cmd!(%"echo foo");
+                let StdoutUntrimmed(output) = run_output!(%"echo foo");
                 assert_eq!(output, "foo\n");
             }
 
             #[test]
             fn works_for_later_arguments() {
-                let StdoutUntrimmed(output) = cmd!("echo", %"foo\tbar");
+                let StdoutUntrimmed(output) = run_output!("echo", %"foo\tbar");
                 assert_eq!(output, "foo bar\n");
             }
 
             #[test]
             fn for_first_of_multiple_arguments() {
-                let StdoutUntrimmed(output) = cmd!(%"echo foo", "bar");
+                let StdoutUntrimmed(output) = run_output!(%"echo foo", "bar");
                 assert_eq!(output, "foo bar\n");
             }
 
             #[test]
             fn non_literals() {
                 let command = "echo foo";
-                let StdoutUntrimmed(output) = cmd!(%command);
+                let StdoutUntrimmed(output) = run_output!(%command);
                 assert_eq!(output, "foo\n");
             }
 
@@ -1237,19 +1241,19 @@ mod tests {
 
         #[test]
         fn allow_to_use_split() {
-            let StdoutTrimmed(output) = cmd!("echo foo".split(' '));
+            let StdoutTrimmed(output) = run_output!("echo foo".split(' '));
             assert_eq!(output, "foo");
         }
 
         #[test]
         fn split_whitespace() {
-            let StdoutTrimmed(output) = cmd!("echo foo".split_whitespace());
+            let StdoutTrimmed(output) = run_output!("echo foo".split_whitespace());
             assert_eq!(output, "foo");
         }
 
         #[test]
         fn split_ascii_whitespace() {
-            let StdoutTrimmed(output) = cmd!("echo foo".split_ascii_whitespace());
+            let StdoutTrimmed(output) = run_output!("echo foo".split_ascii_whitespace());
             assert_eq!(output, "foo");
         }
     }
@@ -1279,7 +1283,7 @@ mod tests {
             in_temporary_directory(|| {
                 let file: &Path = Path::new("file");
                 fs::write(file, "test-contents").unwrap();
-                let StdoutUntrimmed(output) = cmd!("cat", file);
+                let StdoutUntrimmed(output) = run_output!("cat", file);
                 assert_eq!(output, "test-contents");
             })
         }
@@ -1288,7 +1292,7 @@ mod tests {
         fn ref_path_as_executable() {
             in_temporary_directory(|| {
                 let file: &Path = &write_test_script();
-                let StdoutTrimmed(output) = cmd!(file);
+                let StdoutTrimmed(output) = run_output!(file);
                 assert_eq!(output, "test-output");
             })
         }
@@ -1298,7 +1302,7 @@ mod tests {
             in_temporary_directory(|| {
                 let file: PathBuf = PathBuf::from("file");
                 fs::write(&file, "test-contents").unwrap();
-                let StdoutUntrimmed(output) = cmd!("cat", file);
+                let StdoutUntrimmed(output) = run_output!("cat", file);
                 assert_eq!(output, "test-contents");
             })
         }
@@ -1307,7 +1311,7 @@ mod tests {
         fn path_buf_as_executable() {
             in_temporary_directory(|| {
                 let file: PathBuf = write_test_script();
-                let StdoutTrimmed(output) = cmd!(file);
+                let StdoutTrimmed(output) = run_output!(file);
                 assert_eq!(output, "test-output");
             })
         }
@@ -1318,20 +1322,20 @@ mod tests {
 
         #[test]
         fn allows_to_pass_in_strings_as_stdin() {
-            let StdoutUntrimmed(output) = cmd!(test_helper(), "reverse", Stdin("foo"));
+            let StdoutUntrimmed(output) = run_output!(test_helper(), "reverse", Stdin("foo"));
             assert_eq!(output, "oof");
         }
 
         #[test]
         fn allows_passing_in_u8_slices_as_stdin() {
-            let StdoutUntrimmed(output) = cmd!(test_helper(), "reverse", Stdin(&[0, 1, 2]));
+            let StdoutUntrimmed(output) = run_output!(test_helper(), "reverse", Stdin(&[0, 1, 2]));
             assert_eq!(output, "\x02\x01\x00");
         }
 
         #[test]
         #[cfg(unix)]
         fn stdin_is_closed_by_default() {
-            let StdoutTrimmed(output) = cmd!(test_helper(), "wait until stdin is closed");
+            let StdoutTrimmed(output) = run_output!(test_helper(), "wait until stdin is closed");
             assert_eq!(output, "stdin is closed");
         }
 
@@ -1354,14 +1358,14 @@ mod tests {
         #[test]
         fn multiple_stdin_arguments_are_all_passed_into_the_child_process() {
             let StdoutUntrimmed(output) =
-                cmd!(test_helper(), "reverse", Stdin("foo"), Stdin("bar"));
+                run_output!(test_helper(), "reverse", Stdin("foo"), Stdin("bar"));
             assert_eq!(output, "raboof");
         }
 
         #[test]
         fn works_for_owned_strings() {
             let argument: String = "foo".to_string();
-            let StdoutUntrimmed(output) = cmd!(test_helper(), "reverse", Stdin(argument));
+            let StdoutUntrimmed(output) = run_output!(test_helper(), "reverse", Stdin(argument));
             assert_eq!(output, "oof");
         }
     }
@@ -1372,14 +1376,14 @@ mod tests {
         #[test]
         fn trailing_comma_is_accepted_after_normal_argument() {
             run!("echo", "foo",);
-            let StdoutUntrimmed(_) = cmd!("echo", "foo",);
+            let StdoutUntrimmed(_) = run_output!("echo", "foo",);
             let _result: Result<(), Error> = cmd_result!("echo", "foo",);
         }
 
         #[test]
         fn trailing_comma_is_accepted_after_split_argument() {
             run!("echo", %"foo",);
-            let StdoutUntrimmed(_) = cmd!("echo", %"foo",);
+            let StdoutUntrimmed(_) = run_output!("echo", %"foo",);
             let _result: Result<(), Error> = cmd_result!("echo", %"foo",);
         }
     }
@@ -1391,7 +1395,7 @@ mod tests {
 
         #[test]
         fn allows_to_add_variables() {
-            let StdoutTrimmed(output) = cmd!(
+            let StdoutTrimmed(output) = run_output!(
                 test_helper(),
                 %"echo FOO",
                 Env("FOO", "bar")
@@ -1401,7 +1405,7 @@ mod tests {
 
         #[test]
         fn works_for_multiple_variables() {
-            let StdoutUntrimmed(output) = cmd!(
+            let StdoutUntrimmed(output) = run_output!(
                 test_helper(),
                 %"echo FOO BAR",
                 Env("FOO", "a"),
@@ -1425,7 +1429,7 @@ mod tests {
         fn child_processes_inherit_the_environment() {
             let unused_key = find_unused_environment_variable();
             env::set_var(&unused_key, "foo");
-            let StdoutTrimmed(output) = cmd!(test_helper(), "echo", unused_key);
+            let StdoutTrimmed(output) = run_output!(test_helper(), "echo", unused_key);
             assert_eq!(output, "foo");
         }
 
@@ -1434,13 +1438,13 @@ mod tests {
             let unused_key = find_unused_environment_variable();
             env::set_var(&unused_key, "foo");
             let StdoutTrimmed(output) =
-                cmd!(test_helper(), "echo", &unused_key, Env(unused_key, "bar"));
+                run_output!(test_helper(), "echo", &unused_key, Env(unused_key, "bar"));
             assert_eq!(output, "bar");
         }
 
         #[test]
         fn variables_are_overwritten_by_subsequent_variables_with_the_same_name() {
-            let StdoutTrimmed(output) = cmd!(
+            let StdoutTrimmed(output) = run_output!(
                 test_helper(),
                 "echo",
                 "FOO",
@@ -1452,7 +1456,8 @@ mod tests {
 
         #[test]
         fn variables_can_be_set_to_the_empty_string() {
-            let StdoutUntrimmed(output) = cmd!(test_helper(), "echo", "FOO", Env("FOO", ""),);
+            let StdoutUntrimmed(output) =
+                run_output!(test_helper(), "echo", "FOO", Env("FOO", ""),);
             assert_eq!(output, "empty variable: FOO\n");
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,7 +367,7 @@ mod tests {
 
             #[rustversion::since(1.46)]
             #[test]
-            fn includes_source_location_of_cmd_call() {
+            fn includes_source_location_of_run_run_call() {
                 let (Status(_), Stderr(stderr)) =
                     run_output!(test_executable("test_executables_panic"));
                 let expected = "src/test_executables/panic.rs:4:5";
@@ -1230,7 +1230,7 @@ mod tests {
             }
 
             #[test]
-            fn in_cmd_result() {
+            fn in_run_result() {
                 let StdoutTrimmed(_) = run_result!(%"echo foo").unwrap();
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,6 +229,8 @@
 //! [`cmd`](https://hackage.haskell.org/package/shake-0.19.4/docs/Development-Shake.html#v:cmd)
 //! function.
 
+#[doc(hidden)]
+pub mod child_output;
 mod collected_output;
 #[doc(hidden)]
 pub mod config;
@@ -239,8 +241,6 @@ pub mod input;
 mod macros;
 pub mod output;
 pub mod prelude;
-#[doc(hidden)]
-pub mod run_result;
 
 pub use crate::error::Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@
 //!
 //! `cradle` also provides an alternative interface to execute commands
 //! through methods on the [`Input`](input::Input) trait:
-//! [`.run_output()`](input::Input::run_output), [`.run_unit()`](input::Input::run_unit)
+//! [`.run_output()`](input::Input::run_output), [`.run()`](input::Input::run)
 //! and [`.run_result()`](input::Input::run_result).
 //! These methods can be invoked on all values whose types implement
 //! [`Input`](input::Input).
@@ -192,7 +192,7 @@
 //! let StdoutTrimmed(output) = ("echo", "foo").run_output();
 //! assert_eq!(output, "foo");
 //!
-//! ("touch", "foo").run_unit();
+//! ("touch", "foo").run();
 //!
 //! let result: Result<(), cradle::Error> = "false".run_result();
 //! let error_message = format!("{}", result.unwrap_err());
@@ -208,8 +208,8 @@
 //! ```
 //! use cradle::prelude::*;
 //!
-//! ("echo", "foo").run_unit();
-//! Split("echo foo").run_unit();
+//! ("echo", "foo").run();
+//! Split("echo foo").run();
 //! ```
 //!
 //! # Prior Art
@@ -1485,9 +1485,9 @@ mod tests {
         }
 
         #[test]
-        fn run_unit() {
+        fn run() {
             in_temporary_directory(|| {
-                ("touch", "foo").run_unit();
+                ("touch", "foo").run();
                 assert!(Path::new("foo").exists());
             });
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,8 +95,7 @@
 //! let () = cmd!(%"touch foo");
 //! ```
 //!
-//! Since that's a very common case, `cradle` provides the [`cmd_unit!`] shortcut.
-//! It's named after [the unit type `()`](https://doc.rust-lang.org/std/primitive.unit.html).
+//! Since that's a very common case, `cradle` provides the [`run!`] shortcut.
 //! It behaves exactly like [`cmd!`] but always returns `()`.
 //!
 //! ```
@@ -104,7 +103,7 @@
 //! # std::env::set_current_dir(&temp_dir).unwrap();
 //! use cradle::prelude::*;
 //!
-//! cmd_unit!(%"touch foo");
+//! run!(%"touch foo");
 //! ```
 //!
 //! See the implementations for [`output::Output`] for all the supported types.
@@ -123,7 +122,7 @@
 //! use cradle::prelude::*;
 //!
 //! // panics with "false:\n  exited with exit code: 1"
-//! cmd_unit!("false");
+//! run!("false");
 //! ```
 //!
 //! You can suppress panics caused by non-zero exit codes by using the
@@ -182,7 +181,7 @@
 //! [`Input`](input::Input).
 //! When using these methods, it's especially useful that
 //! [`Input`](input::Input) is implemented by tuples.
-//! They work analog to [`cmd!`], [`cmd_unit!`] and [`cmd_result!`].
+//! They work analog to [`cmd!`], [`run!`] and [`cmd_result!`].
 //! Here are some examples:
 //!
 //! ```
@@ -287,7 +286,7 @@ mod tests {
         };
         if !set.contains(name) {
             set.insert(name.to_owned());
-            cmd_unit!(
+            run!(
                 LogCommand,
                 CurrentDir(std::env::var("CARGO_MANIFEST_DIR").unwrap()),
                 %"cargo build",
@@ -313,7 +312,7 @@ mod tests {
     #[test]
     fn allows_to_execute_a_command() {
         in_temporary_directory(|| {
-            cmd_unit!(%"touch foo");
+            run!(%"touch foo");
             assert!(PathBuf::from("foo").exists());
         })
     }
@@ -327,7 +326,7 @@ mod tests {
             #[test]
             #[should_panic(expected = "cmd!: false:\n  exited with exit code: 1")]
             fn non_zero_exit_codes() {
-                cmd_unit!("false");
+                run!("false");
             }
 
             #[test]
@@ -339,19 +338,19 @@ mod tests {
             #[test]
             #[should_panic(expected = "cmd!: false foo bar:\n  exited with exit code: 1")]
             fn includes_full_command_on_non_zero_exit_codes() {
-                cmd_unit!(%"false foo bar");
+                run!(%"false foo bar");
             }
 
             #[test]
             #[should_panic(expected = "exited with exit code: 42")]
             fn other_exit_codes() {
-                cmd_unit!(test_helper(), "exit code 42");
+                run!(test_helper(), "exit code 42");
             }
 
             #[test]
             #[should_panic(expected = "cmd!: File not found error when executing 'does-not-exist'")]
             fn executable_cannot_be_found() {
-                cmd_unit!("does-not-exist");
+                run!("does-not-exist");
             }
 
             #[test]
@@ -361,7 +360,7 @@ mod tests {
                 let temp_dir = TempDir::new().unwrap();
                 let without_executable_bit = temp_dir.path().join("file");
                 fs::write(&without_executable_bit, "").unwrap();
-                cmd_unit!(without_executable_bit, %"foo bar");
+                run!(without_executable_bit, %"foo bar");
             }
 
             #[rustversion::since(1.46)]
@@ -381,7 +380,7 @@ mod tests {
             #[should_panic(expected = "cmd!: no arguments given")]
             fn no_executable() {
                 let vector: Vec<String> = Vec::new();
-                cmd_unit!(vector);
+                run!(vector);
             }
 
             #[test]
@@ -393,7 +392,7 @@ mod tests {
             #[test]
             #[cfg(not(windows))]
             fn invalid_utf8_to_stdout_is_allowed_when_not_captured() {
-                cmd_unit!(test_helper(), "invalid utf-8 stdout");
+                run!(test_helper(), "invalid utf-8 stdout");
             }
         }
 
@@ -627,7 +626,7 @@ mod tests {
         fn elements_in_arrays_are_not_split_by_whitespace() {
             in_temporary_directory(|| {
                 let args: [&str; 1] = ["foo bar"];
-                cmd_unit!("touch", args);
+                run!("touch", args);
                 assert!(PathBuf::from("foo bar").exists());
             });
         }
@@ -645,7 +644,7 @@ mod tests {
         fn elements_in_array_refs_are_not_split_by_whitespace() {
             in_temporary_directory(|| {
                 let args: &[&str; 1] = &["foo bar"];
-                cmd_unit!("touch", args);
+                run!("touch", args);
                 assert!(PathBuf::from("foo bar").exists());
             });
         }
@@ -671,7 +670,7 @@ mod tests {
         fn elements_in_slices_are_not_split_by_whitespace() {
             in_temporary_directory(|| {
                 let args: &[&str] = &["foo bar"];
-                cmd_unit!("touch", args);
+                run!("touch", args);
                 assert!(PathBuf::from("foo bar").exists());
             });
         }
@@ -689,7 +688,7 @@ mod tests {
         #[test]
         fn works_for_string() {
             let command: String = "true".to_string();
-            cmd_unit!(command);
+            run!(command);
         }
 
         #[test]
@@ -711,7 +710,7 @@ mod tests {
         fn does_not_split_strings_in_vectors() {
             in_temporary_directory(|| {
                 let argument: Vec<String> = vec!["filename with spaces".to_string()];
-                cmd_unit!("touch", argument);
+                run!("touch", argument);
                 assert!(PathBuf::from("filename with spaces").exists());
             });
         }
@@ -722,12 +721,12 @@ mod tests {
 
         #[test]
         fn works_for_os_string() {
-            cmd_unit!(OsString::from("true"));
+            run!(OsString::from("true"));
         }
 
         #[test]
         fn works_for_os_str() {
-            cmd_unit!(OsStr::new("true"));
+            run!(OsStr::new("true"));
         }
     }
 
@@ -769,7 +768,7 @@ mod tests {
                 while (context.stdout()) != "foo\n" {
                     thread::sleep(Duration::from_secs_f32(0.05));
                 }
-                cmd_unit!(%"touch file");
+                run!(%"touch file");
                 thread.join().unwrap();
             });
         }
@@ -842,7 +841,7 @@ mod tests {
                     );
                     thread::sleep(Duration::from_secs_f32(0.05));
                 }
-                cmd_unit!(%"touch file");
+                run!(%"touch file");
                 thread.join().unwrap();
             });
         }
@@ -868,7 +867,7 @@ mod tests {
         #[test]
         #[cfg(not(windows))]
         fn does_allow_invalid_utf_8_to_stderr_when_not_captured() {
-            cmd_unit!(test_helper(), "invalid utf-8 stderr");
+            run!(test_helper(), "invalid utf-8 stderr");
         }
 
         #[test]
@@ -1087,11 +1086,11 @@ mod tests {
             in_temporary_directory(|| {
                 fs::create_dir("dir").unwrap();
                 let dir: String = "dir".to_string();
-                cmd_unit!("true", CurrentDir(dir));
+                run!("true", CurrentDir(dir));
                 let dir: PathBuf = PathBuf::from("dir");
-                cmd_unit!("true", CurrentDir(dir));
+                run!("true", CurrentDir(dir));
                 let dir: &Path = Path::new("dir");
-                cmd_unit!("true", CurrentDir(dir));
+                run!("true", CurrentDir(dir));
             });
         }
     }
@@ -1222,8 +1221,8 @@ mod tests {
             }
 
             #[test]
-            fn in_cmd_unit() {
-                cmd_unit!(%"echo foo");
+            fn in_run() {
+                run!(%"echo foo");
             }
 
             #[test]
@@ -1265,7 +1264,7 @@ mod tests {
                 let file = PathBuf::from("./test-script");
                 let script = "#!/usr/bin/env bash\necho test-output\n";
                 fs::write(&file, script).unwrap();
-                cmd_unit!(%"chmod +x test-script");
+                run!(%"chmod +x test-script");
                 file
             } else {
                 let file = PathBuf::from("./test-script.bat");
@@ -1372,14 +1371,14 @@ mod tests {
 
         #[test]
         fn trailing_comma_is_accepted_after_normal_argument() {
-            cmd_unit!("echo", "foo",);
+            run!("echo", "foo",);
             let StdoutUntrimmed(_) = cmd!("echo", "foo",);
             let _result: Result<(), Error> = cmd_result!("echo", "foo",);
         }
 
         #[test]
         fn trailing_comma_is_accepted_after_split_argument() {
-            cmd_unit!("echo", %"foo",);
+            run!("echo", %"foo",);
             let StdoutUntrimmed(_) = cmd!("echo", %"foo",);
             let _result: Result<(), Error> = cmd_result!("echo", %"foo",);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@
 //!
 //! `cradle` also provides an alternative interface to execute commands
 //! through methods on the [`Input`](input::Input) trait:
-//! [`.run()`](input::Input::run), [`.run_unit()`](input::Input::run_unit)
+//! [`.run_output()`](input::Input::run_output), [`.run_unit()`](input::Input::run_unit)
 //! and [`.run_result()`](input::Input::run_result).
 //! These methods can be invoked on all values whose types implement
 //! [`Input`](input::Input).
@@ -189,7 +189,7 @@
 //! # std::env::set_current_dir(&temp_dir).unwrap();
 //! use cradle::prelude::*;
 //!
-//! let StdoutTrimmed(output) = ("echo", "foo").run();
+//! let StdoutTrimmed(output) = ("echo", "foo").run_output();
 //! assert_eq!(output, "foo");
 //!
 //! ("touch", "foo").run_unit();
@@ -1468,19 +1468,19 @@ mod tests {
 
         #[test]
         fn allows_to_run_commands_with_dot_run() {
-            let StdoutTrimmed(output) = Split("echo foo").run();
+            let StdoutTrimmed(output) = Split("echo foo").run_output();
             assert_eq!(output, "foo");
         }
 
         #[test]
         fn allows_to_bundle_arguments_up_in_tuples() {
-            let StdoutTrimmed(output) = ("echo", "foo").run();
+            let StdoutTrimmed(output) = ("echo", "foo").run_output();
             assert_eq!(output, "foo");
         }
 
         #[test]
         fn works_for_different_output_types() {
-            let Status(status) = "false".run();
+            let Status(status) = "false".run_output();
             assert!(!status.success());
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,7 +301,7 @@ mod tests {
         test_executable("test_executables_helper")
     }
 
-    macro_rules! cmd_result_with_context_unit {
+    macro_rules! run_result_with_context_unit {
         ($context:expr, $($args:tt)*) => {{
             let result: std::result::Result<(), $crate::Error> =
               $crate::run_result_with_context!($context, $($args)*);
@@ -740,7 +740,7 @@ mod tests {
         #[test]
         fn relays_stdout_by_default() {
             let context = Context::test();
-            cmd_result_with_context_unit!(context.clone(), %"echo foo").unwrap();
+            run_result_with_context_unit!(context.clone(), %"echo foo").unwrap();
             assert_eq!(context.stdout(), "foo\n");
         }
 
@@ -761,7 +761,7 @@ mod tests {
                 let context = Context::test();
                 let context_clone = context.clone();
                 let thread = thread::spawn(|| {
-                    cmd_result_with_context_unit!(
+                    run_result_with_context_unit!(
                         context_clone,
                         test_helper(),
                         "stream chunk then wait for file"
@@ -801,7 +801,7 @@ mod tests {
         #[test]
         fn relays_stderr_by_default() {
             let context = Context::test();
-            cmd_result_with_context_unit!(context.clone(), test_helper(), "write to stderr")
+            run_result_with_context_unit!(context.clone(), test_helper(), "write to stderr")
                 .unwrap();
             assert_eq!(context.stderr(), "foo\n");
         }
@@ -823,7 +823,7 @@ mod tests {
                 let context = Context::test();
                 let context_clone = context.clone();
                 let thread = thread::spawn(|| {
-                    cmd_result_with_context_unit!(
+                    run_result_with_context_unit!(
                         context_clone,
                         test_helper(),
                         "stream chunk to stderr then wait for file"
@@ -889,28 +889,28 @@ mod tests {
         #[test]
         fn logs_simple_commands() {
             let context = Context::test();
-            cmd_result_with_context_unit!(context.clone(), LogCommand, "true").unwrap();
+            run_result_with_context_unit!(context.clone(), LogCommand, "true").unwrap();
             assert_eq!(context.stderr(), "+ true\n");
         }
 
         #[test]
         fn logs_commands_with_arguments() {
             let context = Context::test();
-            cmd_result_with_context_unit!(context.clone(), LogCommand, %"echo foo").unwrap();
+            run_result_with_context_unit!(context.clone(), LogCommand, %"echo foo").unwrap();
             assert_eq!(context.stderr(), "+ echo foo\n");
         }
 
         #[test]
         fn quotes_arguments_with_spaces() {
             let context = Context::test();
-            cmd_result_with_context_unit!(context.clone(), LogCommand, "echo", "foo bar").unwrap();
+            run_result_with_context_unit!(context.clone(), LogCommand, "echo", "foo bar").unwrap();
             assert_eq!(context.stderr(), "+ echo 'foo bar'\n");
         }
 
         #[test]
         fn quotes_empty_arguments() {
             let context = Context::test();
-            cmd_result_with_context_unit!(context.clone(), LogCommand, "echo", "").unwrap();
+            run_result_with_context_unit!(context.clone(), LogCommand, "echo", "").unwrap();
             assert_eq!(context.stderr(), "+ echo ''\n");
         }
 
@@ -922,7 +922,7 @@ mod tests {
             let argument_with_invalid_utf8: &OsStr =
                 OsStrExt::from_bytes(&[102, 111, 111, 0x80, 98, 97, 114]);
             let argument_with_invalid_utf8: &Path = argument_with_invalid_utf8.as_ref();
-            cmd_result_with_context_unit!(
+            run_result_with_context_unit!(
                 context.clone(),
                 LogCommand,
                 "echo",

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -47,7 +47,7 @@ macro_rules! run {
 macro_rules! run_output {
     ($($args:tt)*) => {{
         let context = $crate::context::Context::production();
-        $crate::error::panic_on_error($crate::cmd_result_with_context!(context, $($args)*))
+        $crate::error::panic_on_error($crate::run_result_with_context!(context, $($args)*))
     }}
 }
 
@@ -57,13 +57,13 @@ macro_rules! run_output {
 macro_rules! run_result {
     ($($args:tt)*) => {{
         let context = $crate::context::Context::production();
-        $crate::cmd_result_with_context!(context, $($args)*)
+        $crate::run_result_with_context!(context, $($args)*)
     }}
 }
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! cmd_result_with_context {
+macro_rules! run_result_with_context {
     ($context:expr, $($args:tt)*) => {{
         let mut config = $crate::config::Config::default();
         $crate::configure!(config: config, args: $($args)*);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,14 +1,4 @@
-/// Execute child processes. See the module documentation on how to use it.
-#[macro_export]
-macro_rules! cmd {
-    ($($args:tt)*) => {{
-        let context = $crate::context::Context::production();
-        $crate::error::panic_on_error($crate::cmd_result_with_context!(context, $($args)*))
-    }}
-}
-
-/// Like [`cmd!`], but fixes the return type to `()`.
-/// It's named after [the unit type `()`](https://doc.rust-lang.org/std/primitive.unit.html).
+/// Executes a child process without capturing any output.
 ///
 /// ```
 /// # let temp_dir = tempfile::TempDir::new().unwrap();
@@ -17,10 +7,47 @@ macro_rules! cmd {
 ///
 /// cmd_unit!(%"touch ./foo");
 /// ```
+///
+/// If an error occurs, `cmd_unit!` will panic.
+/// See [`crate::error::Error`] for possible errors.
+///
+/// For capturing output from child processes, see [`crate::cmd!`].
 #[macro_export]
 macro_rules! cmd_unit {
     ($($args:tt)*) => {{
         let () = $crate::cmd!($($args)*);
+    }}
+}
+
+/// Execute child processes, and capture some output.
+/// For example you can capture what the child process writes to stdout:
+///
+/// ```
+/// use cradle::prelude::*;
+///
+/// let StdoutUntrimmed(output) = cmd!(%"echo foo");
+/// assert_eq!(output, "foo\n");
+/// ```
+///
+/// [`cmd!`] uses return-type polymorphism.
+/// So by using a different return type,
+/// you can control what outputs of child processes you want to capture.
+/// Here's an example to capture an exit code:
+///
+/// ```
+/// use cradle::prelude::*;
+///
+/// let Status(status) = cmd!("false");
+/// assert_eq!(status.code(), Some(1));
+/// ```
+///
+/// You can use any type that implements [`crate::output::Output`] as the return type.
+/// See the module documentation for more comprehensive documentation.
+#[macro_export]
+macro_rules! cmd {
+    ($($args:tt)*) => {{
+        let context = $crate::context::Context::production();
+        $crate::error::panic_on_error($crate::cmd_result_with_context!(context, $($args)*))
     }}
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -54,7 +54,7 @@ macro_rules! run_output {
 /// Like [`run_output!`], but fixes the return type to [`Result<T, Error>`],
 /// where `T` is any type that implements [`Output`](crate::output::Output).
 #[macro_export]
-macro_rules! cmd_result {
+macro_rules! run_result {
     ($($args:tt)*) => {{
         let context = $crate::context::Context::production();
         $crate::cmd_result_with_context!(context, $($args)*)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -67,7 +67,7 @@ macro_rules! run_result_with_context {
     ($context:expr, $($args:tt)*) => {{
         let mut config = $crate::config::Config::default();
         $crate::configure!(config: config, args: $($args)*);
-        $crate::run_result::RunResult::run_cmd($context, config)
+        $crate::run_result::RunResult::run_child_process_output($context, config)
     }}
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -11,11 +11,11 @@
 /// If an error occurs, `run!` will panic.
 /// See [`crate::error::Error`] for possible errors.
 ///
-/// For capturing output from child processes, see [`crate::cmd!`].
+/// For capturing output from child processes, see [`crate::run_output!`].
 #[macro_export]
 macro_rules! run {
     ($($args:tt)*) => {{
-        let () = $crate::cmd!($($args)*);
+        let () = $crate::run_output!($($args)*);
     }}
 }
 
@@ -25,11 +25,11 @@ macro_rules! run {
 /// ```
 /// use cradle::prelude::*;
 ///
-/// let StdoutUntrimmed(output) = cmd!(%"echo foo");
+/// let StdoutUntrimmed(output) = run_output!(%"echo foo");
 /// assert_eq!(output, "foo\n");
 /// ```
 ///
-/// [`cmd!`] uses return-type polymorphism.
+/// [`run_output!`] uses return-type polymorphism.
 /// So by using a different return type,
 /// you can control what outputs of child processes you want to capture.
 /// Here's an example to capture an exit code:
@@ -37,21 +37,21 @@ macro_rules! run {
 /// ```
 /// use cradle::prelude::*;
 ///
-/// let Status(status) = cmd!("false");
+/// let Status(status) = run_output!("false");
 /// assert_eq!(status.code(), Some(1));
 /// ```
 ///
 /// You can use any type that implements [`crate::output::Output`] as the return type.
 /// See the module documentation for more comprehensive documentation.
 #[macro_export]
-macro_rules! cmd {
+macro_rules! run_output {
     ($($args:tt)*) => {{
         let context = $crate::context::Context::production();
         $crate::error::panic_on_error($crate::cmd_result_with_context!(context, $($args)*))
     }}
 }
 
-/// Like [`cmd!`], but fixes the return type to [`Result<T, Error>`],
+/// Like [`run_output!`], but fixes the return type to [`Result<T, Error>`],
 /// where `T` is any type that implements [`Output`](crate::output::Output).
 #[macro_export]
 macro_rules! cmd_result {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -67,7 +67,7 @@ macro_rules! run_result_with_context {
     ($context:expr, $($args:tt)*) => {{
         let mut config = $crate::config::Config::default();
         $crate::configure!(config: config, args: $($args)*);
-        $crate::run_result::RunResult::run_child_process_output($context, config)
+        $crate::child_output::ChildOutput::run_child_process_output($context, config)
     }}
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -5,15 +5,15 @@
 /// # std::env::set_current_dir(&temp_dir).unwrap();
 /// use cradle::prelude::*;
 ///
-/// cmd_unit!(%"touch ./foo");
+/// run!(%"touch ./foo");
 /// ```
 ///
-/// If an error occurs, `cmd_unit!` will panic.
+/// If an error occurs, `run!` will panic.
 /// See [`crate::error::Error`] for possible errors.
 ///
 /// For capturing output from child processes, see [`crate::cmd!`].
 #[macro_export]
-macro_rules! cmd_unit {
+macro_rules! run {
     ($($args:tt)*) => {{
         let () = $crate::cmd!($($args)*);
     }}

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,11 +1,11 @@
 //! The [`Output`] trait that defines all possible outputs of [`run_output!`],
-//! [`run!`] and [`cmd_result!`].
+//! [`run!`] and [`run_result!`].
 
 use crate::{config::Config, error::Error, run_result::RunResult};
 use std::{process::ExitStatus, sync::Arc};
 
 /// All possible return types of [`run_output!`], [`run!`] or
-/// [`cmd_result!`] must implement this trait.
+/// [`run_result!`] must implement this trait.
 /// This return-type polymorphism makes cradle very flexible.
 /// For example, if you want to capture what a command writes
 /// to `stdout` you can do that using [`StdoutUntrimmed`]:
@@ -70,7 +70,7 @@ pub trait Output: Sized {
 /// let () = run_output!(%"touch ./foo");
 /// ```
 ///
-/// Since [`run_output!`] (and [`cmd_result`]) use return type polymorphism,
+/// Since [`run_output!`] (and [`run_result`]) use return type polymorphism,
 /// you have to make sure the compiler can figure out which return type you want to use.
 /// In this example that happens through the `let () =`.
 /// So you can't just omit that.
@@ -240,7 +240,7 @@ impl Output for Stderr {
 ///
 /// let Status(exit_status) = run_output!("false");
 /// assert_eq!(exit_status.code(), Some(1));
-/// let result: Result<Status, cradle::Error> = cmd_result!("false");
+/// let result: Result<Status, cradle::Error> = run_result!("false");
 /// assert!(result.is_ok());
 /// assert_eq!(result.unwrap().0.code(), Some(1));
 /// ```
@@ -282,7 +282,7 @@ impl Output for Status {
 ///
 /// let success: bool = run_output!("false");
 /// assert!(!success);
-/// let result: Result<bool, cradle::Error> = cmd_result!("false");
+/// let result: Result<bool, cradle::Error> = run_result!("false");
 /// assert!(result.is_ok());
 /// assert_eq!(result.unwrap(), false);
 /// ```

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,10 +1,9 @@
-//! The [`Output`] trait that defines all possible outputs of [`run_output!`],
-//! [`run!`] and [`run_result!`].
+//! The [`Output`] trait that defines all possible outputs of `cradle`.
 
 use crate::{config::Config, error::Error, run_result::RunResult};
 use std::{process::ExitStatus, sync::Arc};
 
-/// All possible return types of [`run_output!`], [`run!`] or
+/// All possible return types of [`run!`], [`run_output!`] or
 /// [`run_result!`] must implement this trait.
 /// This return-type polymorphism makes cradle very flexible.
 /// For example, if you want to capture what a command writes

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,4 +1,4 @@
-//! The [`Output`] trait that defines all possible outputs of `cradle`.
+//! The [`Output`] trait that defines all possible outputs of a child process.
 
 use crate::{child_output::ChildOutput, config::Config, error::Error};
 use std::{process::ExitStatus, sync::Arc};

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,10 +1,10 @@
-//! The [`Output`] trait that defines all possible outputs of [`cmd!`],
+//! The [`Output`] trait that defines all possible outputs of [`run_output!`],
 //! [`run!`] and [`cmd_result!`].
 
 use crate::{config::Config, error::Error, run_result::RunResult};
 use std::{process::ExitStatus, sync::Arc};
 
-/// All possible return types of [`cmd!`], [`run!`] or
+/// All possible return types of [`run_output!`], [`run!`] or
 /// [`cmd_result!`] must implement this trait.
 /// This return-type polymorphism makes cradle very flexible.
 /// For example, if you want to capture what a command writes
@@ -13,7 +13,7 @@ use std::{process::ExitStatus, sync::Arc};
 /// ```
 /// use cradle::prelude::*;
 ///
-/// let StdoutUntrimmed(output) = cmd!(%"echo foo");
+/// let StdoutUntrimmed(output) = run_output!(%"echo foo");
 /// assert_eq!(output, "foo\n");
 /// ```
 ///
@@ -23,7 +23,7 @@ use std::{process::ExitStatus, sync::Arc};
 /// ```
 /// use cradle::prelude::*;
 ///
-/// let Status(exit_status) = cmd!("false");
+/// let Status(exit_status) = run_output!("false");
 /// assert_eq!(exit_status.code(), Some(1));
 /// ```
 ///
@@ -46,7 +46,7 @@ use std::{process::ExitStatus, sync::Arc};
 /// ```
 /// use cradle::prelude::*;
 ///
-/// let (Status(exit_status), StdoutUntrimmed(stdout)) = cmd!(%"echo foo");
+/// let (Status(exit_status), StdoutUntrimmed(stdout)) = run_output!(%"echo foo");
 /// assert!(exit_status.success());
 /// assert_eq!(stdout, "foo\n");
 /// ```
@@ -67,10 +67,10 @@ pub trait Output: Sized {
 /// # std::env::set_current_dir(&temp_dir).unwrap();
 /// use cradle::prelude::*;
 ///
-/// let () = cmd!(%"touch ./foo");
+/// let () = run_output!(%"touch ./foo");
 /// ```
 ///
-/// Since [`cmd!`] (and [`cmd_result`]) use return type polymorphism,
+/// Since [`run_output!`] (and [`cmd_result`]) use return type polymorphism,
 /// you have to make sure the compiler can figure out which return type you want to use.
 /// In this example that happens through the `let () =`.
 /// So you can't just omit that.
@@ -131,7 +131,7 @@ tuple_impl!(A, B, C, D, E, F,);
 ///
 /// # #[cfg(unix)]
 /// # {
-/// let StdoutTrimmed(output) = cmd!(%"which ls");
+/// let StdoutTrimmed(output) = run_output!(%"which ls");
 /// assert!(Path::new(&output).exists());
 /// # }
 /// ```
@@ -156,7 +156,7 @@ impl Output for StdoutTrimmed {
 /// ```
 /// use cradle::prelude::*;
 ///
-/// let StdoutUntrimmed(output) = cmd!(%"echo foo");
+/// let StdoutUntrimmed(output) = run_output!(%"echo foo");
 /// assert_eq!(output, "foo\n");
 /// ```
 #[derive(Debug, PartialEq, Clone)]
@@ -189,7 +189,7 @@ impl Output for StdoutUntrimmed {
 ///
 /// // (`Status` is used here to suppress panics caused by `ls`
 /// // terminating with a non-zero exit code.)
-/// let (Stderr(stderr), Status(_)) = cmd!(%"ls does-not-exist");
+/// let (Stderr(stderr), Status(_)) = run_output!(%"ls does-not-exist");
 /// assert!(stderr.contains("No such file or directory"));
 /// ```
 ///
@@ -222,13 +222,13 @@ impl Output for Stderr {
     }
 }
 
-/// Use [`Status`] as the return type for [`cmd!`] to retrieve the
+/// Use [`Status`] as the return type for [`run_output!`] to retrieve the
 /// [`ExitStatus`] of the child process:
 ///
 /// ```
 /// use cradle::prelude::*;
 ///
-/// let Status(exit_status) = cmd!(%"echo foo");
+/// let Status(exit_status) = run_output!(%"echo foo");
 /// assert!(exit_status.success());
 /// ```
 ///
@@ -238,7 +238,7 @@ impl Output for Stderr {
 /// ```
 /// use cradle::prelude::*;
 ///
-/// let Status(exit_status) = cmd!("false");
+/// let Status(exit_status) = run_output!("false");
 /// assert_eq!(exit_status.code(), Some(1));
 /// let result: Result<Status, cradle::Error> = cmd_result!("false");
 /// assert!(result.is_ok());
@@ -263,13 +263,13 @@ impl Output for Status {
     }
 }
 
-/// Using [`bool`] as the return type for [`cmd!`] will return `true` if
+/// Using [`bool`] as the return type for [`run_output!`] will return `true` if
 /// the command returned successfully, and `false` otherwise:
 ///
 /// ```
 /// use cradle::prelude::*;
 ///
-/// if !cmd!(%"which cargo") {
+/// if !run_output!(%"which cargo") {
 ///     panic!("Cargo is not installed!");
 /// }
 /// ```
@@ -280,7 +280,7 @@ impl Output for Status {
 /// ```
 /// use cradle::prelude::*;
 ///
-/// let success: bool = cmd!("false");
+/// let success: bool = run_output!("false");
 /// assert!(!success);
 /// let result: Result<bool, cradle::Error> = cmd_result!("false");
 /// assert!(result.is_ok());

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,10 +1,10 @@
 //! The [`Output`] trait that defines all possible outputs of [`cmd!`],
-//! [`cmd_unit!`] and [`cmd_result!`].
+//! [`run!`] and [`cmd_result!`].
 
 use crate::{config::Config, error::Error, run_result::RunResult};
 use std::{process::ExitStatus, sync::Arc};
 
-/// All possible return types of [`cmd!`], [`cmd_unit!`] or
+/// All possible return types of [`cmd!`], [`run!`] or
 /// [`cmd_result!`] must implement this trait.
 /// This return-type polymorphism makes cradle very flexible.
 /// For example, if you want to capture what a command writes
@@ -31,7 +31,7 @@ use std::{process::ExitStatus, sync::Arc};
 /// see the documentation for the individual impls of [`Output`].
 /// Here's a non-exhaustive list of the more commonly used return types to get you started:
 ///
-/// - [`()`]: In case you don't want to capture anything. See also [`cmd_unit`].
+/// - [`()`]: In case you don't want to capture anything. See also [`run`].
 /// - To capture output streams:
 ///   - [`StdoutTrimmed`]: To capture `stdout`, trimmed of whitespace.
 ///   - [`StdoutUntrimmed`]: To capture `stdout` untrimmed.
@@ -75,7 +75,7 @@ pub trait Output: Sized {
 /// In this example that happens through the `let () =`.
 /// So you can't just omit that.
 ///
-/// See also [`cmd_unit!`] for a more convenient way to use `()` as the return type.
+/// See also [`run!`] for a more convenient way to use `()` as the return type.
 impl Output for () {
     #[doc(hidden)]
     fn configure(_config: &mut Config) {}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,4 @@
-//! Cradle's `prelude` module.
+//! `cradle`'s `prelude` module.
 //! It re-exports the most commonly used items from cradle.
 //! We recommend importing cradle like this:
 //! `use cradle::prelude::*;`

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,9 +7,9 @@
 //! see the documentation in the [crate root](crate).
 
 pub use crate::{
-    cmd, cmd_result,
+    cmd_result,
     error::Error,
     input::{CurrentDir, Env, Input, LogCommand, Split, Stdin},
     output::{Output, Status, Stderr, StdoutTrimmed, StdoutUntrimmed},
-    run,
+    run, run_output,
 };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,8 +7,9 @@
 //! see the documentation in the [crate root](crate).
 
 pub use crate::{
-    cmd, cmd_result, cmd_unit,
+    cmd, cmd_result,
     error::Error,
     input::{CurrentDir, Env, Input, LogCommand, Split, Stdin},
     output::{Output, Status, Stderr, StdoutTrimmed, StdoutUntrimmed},
+    run,
 };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,9 +7,8 @@
 //! see the documentation in the [crate root](crate).
 
 pub use crate::{
-    cmd_result,
     error::Error,
     input::{CurrentDir, Env, Input, LogCommand, Split, Stdin},
     output::{Output, Status, Stderr, StdoutTrimmed, StdoutUntrimmed},
-    run, run_output,
+    run, run_output, run_result,
 };

--- a/src/run_result.rs
+++ b/src/run_result.rs
@@ -17,7 +17,7 @@ pub struct RunResult {
 }
 
 impl RunResult {
-    pub fn run_cmd<Stdout, Stderr, T>(
+    pub fn run_child_process_output<Stdout, Stderr, T>(
         context: Context<Stdout, Stderr>,
         mut config: Config,
     ) -> Result<T, Error>
@@ -27,11 +27,11 @@ impl RunResult {
         T: Output,
     {
         <T as Output>::configure(&mut config);
-        let result = RunResult::run_cmd_safe(context, &config);
+        let result = RunResult::run_child_process(context, &config);
         T::from_run_result(&config, result)
     }
 
-    pub(crate) fn run_cmd_safe<Stdout, Stderr>(
+    pub(crate) fn run_child_process<Stdout, Stderr>(
         mut context: Context<Stdout, Stderr>,
         config: &Config,
     ) -> Result<Self, Error>

--- a/src/run_result.rs
+++ b/src/run_result.rs
@@ -31,7 +31,7 @@ impl RunResult {
         T::from_run_result(&config, result)
     }
 
-    pub(crate) fn run_child_process<Stdout, Stderr>(
+    fn run_child_process<Stdout, Stderr>(
         mut context: Context<Stdout, Stderr>,
         config: &Config,
     ) -> Result<Self, Error>

--- a/src/test_executables/panic.rs
+++ b/src/test_executables/panic.rs
@@ -1,5 +1,5 @@
 use cradle::*;
 
 fn main() {
-    cmd_unit!("false");
+    run!("false");
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -125,12 +125,12 @@ fn user_supplied_errors_succeeding() {
 
     #[derive(Debug)]
     enum Error {
-        CmdError(cradle::Error),
+        CradleError(cradle::Error),
     }
 
     impl From<cradle::Error> for Error {
         fn from(error: cradle::Error) -> Self {
-            Error::CmdError(error)
+            Error::CradleError(error)
         }
     }
 
@@ -149,19 +149,19 @@ fn user_supplied_errors_failing() {
 
     #[derive(Debug)]
     enum Error {
-        CmdError(cradle::Error),
+        CradleError(cradle::Error),
     }
 
     impl From<cradle::Error> for Error {
         fn from(error: cradle::Error) -> Self {
-            Error::CmdError(error)
+            Error::CradleError(error)
         }
     }
 
     impl Display for Error {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             match self {
-                Error::CmdError(error) => write!(f, "cmd-error: {}", error),
+                Error::CradleError(error) => write!(f, "cradle error: {}", error),
             }
         }
     }
@@ -174,9 +174,9 @@ fn user_supplied_errors_failing() {
     assert_eq!(
         test().unwrap_err().to_string(),
         if cfg!(unix) {
-            "cmd-error: which does-not-exist:\n  exited with exit code: 1"
+            "cradle error: which does-not-exist:\n  exited with exit code: 1"
         } else {
-            "cmd-error: where does-not-exist:\n  exited with exit code: 1"
+            "cradle error: where does-not-exist:\n  exited with exit code: 1"
         }
     );
 }
@@ -257,12 +257,12 @@ mod run_interface {
 
         #[derive(Debug)]
         enum Error {
-            CmdError(cradle::Error),
+            CradleError(cradle::Error),
         }
 
         impl From<cradle::Error> for Error {
             fn from(error: cradle::Error) -> Self {
-                Error::CmdError(error)
+                Error::CradleError(error)
             }
         }
 
@@ -281,19 +281,19 @@ mod run_interface {
 
         #[derive(Debug)]
         enum Error {
-            CmdError(cradle::Error),
+            CradleError(cradle::Error),
         }
 
         impl From<cradle::Error> for Error {
             fn from(error: cradle::Error) -> Self {
-                Error::CmdError(error)
+                Error::CradleError(error)
             }
         }
 
         impl Display for Error {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 match self {
-                    Error::CmdError(error) => write!(f, "cmd-error: {}", error),
+                    Error::CradleError(error) => write!(f, "cradle error: {}", error),
                 }
             }
         }
@@ -306,9 +306,9 @@ mod run_interface {
         assert_eq!(
             test().unwrap_err().to_string(),
             if cfg!(unix) {
-                "cmd-error: which does-not-exist:\n  exited with exit code: 1"
+                "cradle error: which does-not-exist:\n  exited with exit code: 1"
             } else {
-                "cmd-error: where does-not-exist:\n  exited with exit code: 1"
+                "cradle error: where does-not-exist:\n  exited with exit code: 1"
             }
         );
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7,7 +7,7 @@ const WHICH: &str = "where";
 fn capturing_stdout() {
     use cradle::prelude::*;
 
-    let StdoutTrimmed(output) = cmd!(%"echo foo");
+    let StdoutTrimmed(output) = run_output!(%"echo foo");
     assert_eq!(output, "foo");
 }
 
@@ -57,7 +57,7 @@ fn trimmed_stdout() {
     use std::path::PathBuf;
 
     {
-        let StdoutTrimmed(ls_path) = cmd!(WHICH, "ls");
+        let StdoutTrimmed(ls_path) = run_output!(WHICH, "ls");
         assert!(
             PathBuf::from(&ls_path).exists(),
             "{:?} does not exist",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -25,7 +25,7 @@ fn result_succeeding() {
 
     fn test() -> Result<(), Error> {
         // make sure 'ls' is installed
-        cmd_result!(WHICH, "ls")?;
+        run_result!(WHICH, "ls")?;
         Ok(())
     }
 
@@ -37,7 +37,7 @@ fn result_failing() {
     use cradle::prelude::*;
 
     fn test() -> Result<(), Error> {
-        cmd_result!(WHICH, "does-not-exist")?;
+        run_result!(WHICH, "does-not-exist")?;
         Ok(())
     }
 
@@ -72,7 +72,7 @@ fn trimmed_stdout_and_results() {
     use std::path::PathBuf;
 
     fn test() -> Result<(), Error> {
-        let StdoutTrimmed(ls_path) = cmd_result!(WHICH, "ls")?;
+        let StdoutTrimmed(ls_path) = run_result!(WHICH, "ls")?;
         assert!(
             PathBuf::from(&ls_path).exists(),
             "{:?} does not exist",
@@ -91,7 +91,7 @@ fn box_dyn_errors_succeeding() {
     type MyResult<T> = Result<T, Box<dyn std::error::Error>>;
 
     fn test() -> MyResult<()> {
-        cmd_result!(WHICH, "ls")?;
+        run_result!(WHICH, "ls")?;
         Ok(())
     }
 
@@ -105,7 +105,7 @@ fn box_dyn_errors_failing() {
     type MyResult<T> = Result<T, Box<dyn std::error::Error>>;
 
     fn test() -> MyResult<()> {
-        cmd_result!(WHICH, "does-not-exist")?;
+        run_result!(WHICH, "does-not-exist")?;
         Ok(())
     }
 
@@ -135,7 +135,7 @@ fn user_supplied_errors_succeeding() {
     }
 
     fn test() -> Result<(), Error> {
-        cmd_result!(WHICH, "ls")?;
+        run_result!(WHICH, "ls")?;
         Ok(())
     }
 
@@ -167,7 +167,7 @@ fn user_supplied_errors_failing() {
     }
 
     fn test() -> Result<(), Error> {
-        cmd_result!(WHICH, "does-not-exist")?;
+        run_result!(WHICH, "does-not-exist")?;
         Ok(())
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -16,7 +16,7 @@ fn capturing_stdout() {
 fn panics_on_non_zero_exit_codes() {
     use cradle::prelude::*;
 
-    cmd_unit!("false");
+    run!("false");
 }
 
 #[test]
@@ -318,6 +318,6 @@ mod run_interface {
 #[test]
 fn memory_test() {
     use cradle::prelude::*;
-    cmd_unit!(%"cargo build -p memory-tests --release");
-    cmd_unit!(%"cargo run -p memory-tests --bin run");
+    run!(%"cargo build -p memory-tests --release");
+    run!(%"cargo run -p memory-tests --bin run");
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4,11 +4,13 @@ const WHICH: &str = "which";
 const WHICH: &str = "where";
 
 #[test]
-fn capturing_stdout() {
+fn runs_child_processes() {
     use cradle::prelude::*;
+    use tempfile::TempDir;
 
-    let StdoutTrimmed(output) = run_output!(%"echo foo");
-    assert_eq!(output, "foo");
+    let temp_dir = TempDir::new().unwrap();
+    run!(CurrentDir(temp_dir.path()), %"touch foo");
+    assert!(temp_dir.path().join("foo").is_file());
 }
 
 #[test]
@@ -17,6 +19,14 @@ fn panics_on_non_zero_exit_codes() {
     use cradle::prelude::*;
 
     run!("false");
+}
+
+#[test]
+fn capturing_stdout() {
+    use cradle::prelude::*;
+
+    let StdoutTrimmed(output) = run_output!(%"echo foo");
+    assert_eq!(output, "foo");
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -135,12 +135,12 @@ fn user_supplied_errors_succeeding() {
 
     #[derive(Debug)]
     enum Error {
-        CradleError(cradle::Error),
+        Cradle(cradle::Error),
     }
 
     impl From<cradle::Error> for Error {
         fn from(error: cradle::Error) -> Self {
-            Error::CradleError(error)
+            Error::Cradle(error)
         }
     }
 
@@ -159,19 +159,19 @@ fn user_supplied_errors_failing() {
 
     #[derive(Debug)]
     enum Error {
-        CradleError(cradle::Error),
+        Cradle(cradle::Error),
     }
 
     impl From<cradle::Error> for Error {
         fn from(error: cradle::Error) -> Self {
-            Error::CradleError(error)
+            Error::Cradle(error)
         }
     }
 
     impl Display for Error {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             match self {
-                Error::CradleError(error) => write!(f, "cradle error: {}", error),
+                Error::Cradle(error) => write!(f, "cradle error: {}", error),
             }
         }
     }
@@ -267,12 +267,12 @@ mod run_interface {
 
         #[derive(Debug)]
         enum Error {
-            CradleError(cradle::Error),
+            Cradle(cradle::Error),
         }
 
         impl From<cradle::Error> for Error {
             fn from(error: cradle::Error) -> Self {
-                Error::CradleError(error)
+                Error::Cradle(error)
             }
         }
 
@@ -291,19 +291,19 @@ mod run_interface {
 
         #[derive(Debug)]
         enum Error {
-            CradleError(cradle::Error),
+            Cradle(cradle::Error),
         }
 
         impl From<cradle::Error> for Error {
             fn from(error: cradle::Error) -> Self {
-                Error::CradleError(error)
+                Error::Cradle(error)
             }
         }
 
         impl Display for Error {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 match self {
-                    Error::CradleError(error) => write!(f, "cradle error: {}", error),
+                    Error::Cradle(error) => write!(f, "cradle error: {}", error),
                 }
             }
         }


### PR DESCRIPTION
Fixes #119.

This PR renames the main macros and the `Input::run*` methods. It also makes some other changes that seemed necessary given these renamings. To make it easier to review the PR I took care to have the single commits make sense:
- All commits where the message starts with 'Rename ...' are simple renamings, and contain no other changes.
- The other commits contain more interesting changes.

So maybe it makes sense to review the PR commit by commit. Or maybe not. Not sure how well github handles comments on commits...

Notes:

Commit https://github.com/soenkehahn/cradle/pull/161/commits/2609b633a080c543b178bfba8e7a623cf9468cf2 changes the order of the documentation. I thought, since `run!` (former `cmd_unit!`) is now shorter it would be more natural to document it first. That also allows us to first introduce input polymorphism and then -- when talking about `run_output!` (former `cmd!`) -- introduce return-type polymorphism. Which makes for a slightly nicer difficulty curve.

Commit https://github.com/soenkehahn/cradle/pull/161/commits/2fab2ee75a358e3bac21e4d2e9622050a451d43c renames the `RunResult` type to `ChildOutput`. And consequently it renames the containing module from `run_result` to `child_output`. This is because it was a bit confusing that we had 1. a macro called `run_result`, 2. an `Input::run_result` method with the same behavior and then 3. a `run_result` module that is pretty unrelated to the other items with the same name.