### PR TITLE
Simplify Output::from_run_result

### DIFF
--- a/src/child_output.rs
+++ b/src/child_output.rs
@@ -27,7 +27,7 @@ impl ChildOutput {
         T: Output,
     {
         <T as Output>::configure(&mut config);
-        let result = ChildOutput::run_child_process(context, &config);
+        let result = ChildOutput::run_child_process(context, &config)?;
         T::from_run_result(&config, result)
     }
 


### PR DESCRIPTION
This is a vestigial holdover from some early version of `cradle`.