### PR TITLE
[Refactoring] Implement the main macros in terms of Input::methods on tuples

### DIFF
--- a/src/child_output.rs
+++ b/src/child_output.rs
@@ -17,7 +17,7 @@ pub struct ChildOutput {
 }
 
 impl ChildOutput {
-    pub fn run_child_process_output<Stdout, Stderr, T>(
+    pub(crate) fn run_child_process_output<Stdout, Stderr, T>(
         context: Context<Stdout, Stderr>,
         mut config: Config,
     ) -> Result<T, Error>

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,7 +3,7 @@
 use std::io::{self, Write};
 
 #[derive(Clone, Debug)]
-pub struct Stdout;
+pub(crate) struct Stdout;
 
 impl Write for Stdout {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
@@ -16,7 +16,7 @@ impl Write for Stdout {
 }
 
 #[derive(Clone, Debug)]
-pub struct Stderr;
+pub(crate) struct Stderr;
 
 impl Write for Stderr {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
@@ -30,13 +30,13 @@ impl Write for Stderr {
 
 #[doc(hidden)]
 #[derive(Clone, Debug)]
-pub struct Context<Stdout, Stderr> {
+pub(crate) struct Context<Stdout, Stderr> {
     pub(crate) stdout: Stdout,
     pub(crate) stderr: Stderr,
 }
 
 impl Context<Stdout, Stderr> {
-    pub fn production() -> Self {
+    pub(crate) fn production() -> Self {
         Context {
             stdout: Stdout,
             stderr: Stderr,
@@ -81,12 +81,12 @@ mod test {
             }
         }
 
-        pub fn stdout(&self) -> String {
+        pub(crate) fn stdout(&self) -> String {
             let lock = self.stdout.0.lock().unwrap();
             String::from_utf8(lock.clone().into_inner()).unwrap()
         }
 
-        pub fn stderr(&self) -> String {
+        pub(crate) fn stderr(&self) -> String {
             let lock = self.stderr.0.lock().unwrap();
             String::from_utf8(lock.clone().into_inner()).unwrap()
         }

--- a/src/input.rs
+++ b/src/input.rs
@@ -268,7 +268,7 @@ impl Input for String {
 /// ```
 ///
 /// [`split_whitespace`]: str::split_whitespace
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Split<T: AsRef<str>>(pub T);
 
 impl<T: AsRef<str>> Input for crate::input::Split<T> {

--- a/src/input.rs
+++ b/src/input.rs
@@ -109,6 +109,7 @@ pub trait Input: Sized {
     ///
     /// ("touch", "foo").run();
     /// ```
+    #[track_caller]
     fn run(self) {
         let () = self.run_output();
     }
@@ -122,6 +123,7 @@ pub trait Input: Sized {
     /// let StdoutTrimmed(output) = ("echo", "foo").run_output();
     /// assert_eq!(output, "foo");
     /// ```
+    #[track_caller]
     fn run_output<O>(self) -> O
     where
         O: Output,

--- a/src/input.rs
+++ b/src/input.rs
@@ -109,7 +109,7 @@ pub trait Input: Sized {
     ///
     /// ("touch", "foo").run();
     /// ```
-    #[track_caller]
+    #[rustversion::attr(since(1.46), track_caller)]
     fn run(self) {
         let () = self.run_output();
     }
@@ -123,7 +123,7 @@ pub trait Input: Sized {
     /// let StdoutTrimmed(output) = ("echo", "foo").run_output();
     /// assert_eq!(output, "foo");
     /// ```
-    #[track_caller]
+    #[rustversion::attr(since(1.46), track_caller)]
     fn run_output<O>(self) -> O
     where
         O: Output,

--- a/src/input.rs
+++ b/src/input.rs
@@ -151,19 +151,32 @@ pub trait Input: Sized {
         O: Output,
     {
         let context = Context::production();
-        run_result_with_context(self, context)
+        run_result_with_context(context, self)
     }
 }
 
-pub(crate) fn run_result_with_context<I, O, Stdout, Stderr>(
-    input: I,
+#[cfg(test)]
+pub(crate) fn run_result_with_context_unit<Stdout, Stderr, I>(
     context: Context<Stdout, Stderr>,
-) -> Result<O, Error>
+    input: I,
+) -> Result<(), Error>
 where
-    I: Input,
-    O: Output,
     Stdout: Write + Clone + Send + 'static,
     Stderr: Write + Clone + Send + 'static,
+    I: Input,
+{
+    run_result_with_context(context, input)
+}
+
+pub(crate) fn run_result_with_context<Stdout, Stderr, I, O>(
+    context: Context<Stdout, Stderr>,
+    input: I,
+) -> Result<O, Error>
+where
+    Stdout: Write + Clone + Send + 'static,
+    Stderr: Write + Clone + Send + 'static,
+    I: Input,
+    O: Output,
 {
     let mut config = Config::default();
     input.configure(&mut config);

--- a/src/input.rs
+++ b/src/input.rs
@@ -111,7 +111,7 @@ pub trait Input: Sized {
     /// ```
     #[rustversion::attr(since(1.46), track_caller)]
     fn run(self) {
-        let () = self.run_output();
+        self.run_output()
     }
 
     /// `input.run()` runs `input` as a child process.

--- a/src/input.rs
+++ b/src/input.rs
@@ -155,19 +155,6 @@ pub trait Input: Sized {
     }
 }
 
-#[cfg(test)]
-pub(crate) fn run_result_with_context_unit<Stdout, Stderr, I>(
-    context: Context<Stdout, Stderr>,
-    input: I,
-) -> Result<(), Error>
-where
-    Stdout: Write + Clone + Send + 'static,
-    Stderr: Write + Clone + Send + 'static,
-    I: Input,
-{
-    run_result_with_context(context, input)
-}
-
 pub(crate) fn run_result_with_context<Stdout, Stderr, I, O>(
     context: Context<Stdout, Stderr>,
     input: I,
@@ -181,6 +168,19 @@ where
     let mut config = Config::default();
     input.configure(&mut config);
     ChildOutput::run_child_process_output(context, config)
+}
+
+#[cfg(test)]
+pub(crate) fn run_result_with_context_unit<Stdout, Stderr, I>(
+    context: Context<Stdout, Stderr>,
+    input: I,
+) -> Result<(), Error>
+where
+    Stdout: Write + Clone + Send + 'static,
+    Stderr: Write + Clone + Send + 'static,
+    I: Input,
+{
+    run_result_with_context(context, input)
 }
 
 /// Blanket implementation for `&_`.

--- a/src/input.rs
+++ b/src/input.rs
@@ -151,22 +151,23 @@ pub trait Input: Sized {
         O: Output,
     {
         let context = Context::production();
-        self.run_result_with_context(context)
+        run_result_with_context(self, context)
     }
+}
 
-    fn run_result_with_context<O, Stdout, Stderr>(
-        self,
-        context: Context<Stdout, Stderr>,
-    ) -> Result<O, Error>
-    where
-        O: Output,
-        Stdout: Write + Clone + Send + 'static,
-        Stderr: Write + Clone + Send + 'static,
-    {
-        let mut config = Config::default();
-        self.configure(&mut config);
-        ChildOutput::run_child_process_output(context, config)
-    }
+pub(crate) fn run_result_with_context<I, O, Stdout, Stderr>(
+    input: I,
+    context: Context<Stdout, Stderr>,
+) -> Result<O, Error>
+where
+    I: Input,
+    O: Output,
+    Stdout: Write + Clone + Send + 'static,
+    Stderr: Write + Clone + Send + 'static,
+{
+    let mut config = Config::default();
+    input.configure(&mut config);
+    ChildOutput::run_child_process_output(context, config)
 }
 
 /// Blanket implementation for `&_`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,8 +234,7 @@ pub mod child_output;
 mod collected_output;
 #[doc(hidden)]
 pub mod config;
-#[doc(hidden)]
-pub mod context;
+mod context;
 pub mod error;
 pub mod input;
 mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,7 +246,11 @@ pub use crate::error::Error;
 
 #[cfg(test)]
 mod tests {
-    use crate::{context::Context, input::run_result_with_context, prelude::*};
+    use crate::{
+        context::Context,
+        input::{run_result_with_context, run_result_with_context_unit},
+        prelude::*,
+    };
     use lazy_static::lazy_static;
     use std::{
         collections::BTreeSet,
@@ -308,18 +312,6 @@ mod tests {
 
     fn test_helper() -> PathBuf {
         test_executable("test_executables_helper")
-    }
-
-    fn run_result_with_context_unit<Stdout, Stderr, I>(
-        context: Context<Stdout, Stderr>,
-        input: I,
-    ) -> Result<(), Error>
-    where
-        Stdout: Write + Clone + Send + 'static,
-        Stderr: Write + Clone + Send + 'static,
-        I: Input,
-    {
-        run_result_with_context(input, context)
     }
 
     #[test]
@@ -613,7 +605,7 @@ mod tests {
             let context = Context::test();
             let log_commands: Vec<LogCommand> = vec![LogCommand];
             let StdoutTrimmed(stdout) =
-                run_result_with_context((log_commands, Split("echo foo")), context.clone())
+                run_result_with_context(context.clone(), (log_commands, Split("echo foo")))
                     .unwrap();
             assert_eq!(stdout, "foo");
             assert_eq!(context.stderr(), "+ echo foo\n");
@@ -633,7 +625,7 @@ mod tests {
             let context = Context::test();
             let log_commands: [LogCommand; 1] = [LogCommand];
             let StdoutTrimmed(stdout) =
-                run_result_with_context((log_commands, Split("echo foo")), context.clone())
+                run_result_with_context(context.clone(), (log_commands, Split("echo foo")))
                     .unwrap();
             assert_eq!(stdout, "foo");
             assert_eq!(context.stderr(), "+ echo foo\n");
@@ -679,7 +671,7 @@ mod tests {
             let context = Context::test();
             let log_commands: &[LogCommand] = &[LogCommand];
             let StdoutTrimmed(stdout) =
-                run_result_with_context((log_commands, Split("echo foo")), context.clone())
+                run_result_with_context(context.clone(), (log_commands, Split("echo foo")))
                     .unwrap();
             assert_eq!(stdout, "foo");
             assert_eq!(context.stderr(), "+ echo foo\n");
@@ -794,7 +786,7 @@ mod tests {
         fn does_not_relay_stdout_when_collecting_into_string() {
             let context = Context::test();
             let StdoutTrimmed(_) =
-                run_result_with_context(Split("echo foo"), context.clone()).unwrap();
+                run_result_with_context(context.clone(), Split("echo foo")).unwrap();
             assert_eq!(context.stdout(), "");
         }
 
@@ -802,7 +794,7 @@ mod tests {
         fn does_not_relay_stdout_when_collecting_into_result_of_string() {
             let context = Context::test();
             let _: Result<StdoutTrimmed, Error> =
-                run_result_with_context(Split("echo foo"), context.clone());
+                run_result_with_context(context.clone(), Split("echo foo"));
             assert_eq!(context.stdout(), "");
         }
     }
@@ -824,8 +816,8 @@ mod tests {
         fn relays_stderr_for_non_zero_exit_codes() {
             let context = Context::test();
             let _: Result<(), Error> = run_result_with_context(
-                (test_helper(), "write to stderr and exit with 42"),
                 context.clone(),
+                (test_helper(), "write to stderr and exit with 42"),
             );
             assert_eq!(context.stderr(), "foo\n");
         }
@@ -889,7 +881,7 @@ mod tests {
         fn does_not_relay_stderr_when_catpuring() {
             let context = Context::test();
             let Stderr(_) =
-                run_result_with_context((test_helper(), "write to stderr"), context.clone())
+                run_result_with_context(context.clone(), (test_helper(), "write to stderr"))
                     .unwrap();
             assert_eq!(context.stderr(), "");
         }
@@ -1143,7 +1135,7 @@ mod tests {
             fn does_not_relay_stdout() {
                 let context = Context::test();
                 let StdoutTrimmed(_) =
-                    run_result_with_context(Split("echo foo"), context.clone()).unwrap();
+                    run_result_with_context(context.clone(), Split("echo foo")).unwrap();
                 assert_eq!(context.stdout(), "");
             }
         }
@@ -1167,7 +1159,7 @@ mod tests {
             fn does_not_relay_stdout() {
                 let context = Context::test();
                 let StdoutUntrimmed(_) =
-                    run_result_with_context(Split("echo foo"), context.clone()).unwrap();
+                    run_result_with_context(context.clone(), Split("echo foo")).unwrap();
                 assert_eq!(context.stdout(), "");
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,8 +246,7 @@ pub use crate::error::Error;
 
 #[cfg(test)]
 mod tests {
-    use crate::context::Context;
-    use crate::prelude::*;
+    use crate::{context::Context, input::run_result_with_context, prelude::*};
     use lazy_static::lazy_static;
     use std::{
         collections::BTreeSet,
@@ -320,7 +319,7 @@ mod tests {
         Stderr: Write + Clone + Send + 'static,
         I: Input,
     {
-        input.run_result_with_context(context)
+        run_result_with_context(input, context)
     }
 
     #[test]
@@ -613,9 +612,9 @@ mod tests {
         fn vector_of_non_strings() {
             let context = Context::test();
             let log_commands: Vec<LogCommand> = vec![LogCommand];
-            let StdoutTrimmed(stdout) = (log_commands, Split("echo foo"))
-                .run_result_with_context(context.clone())
-                .unwrap();
+            let StdoutTrimmed(stdout) =
+                run_result_with_context((log_commands, Split("echo foo")), context.clone())
+                    .unwrap();
             assert_eq!(stdout, "foo");
             assert_eq!(context.stderr(), "+ echo foo\n");
         }
@@ -633,9 +632,9 @@ mod tests {
         fn arrays_of_non_strings() {
             let context = Context::test();
             let log_commands: [LogCommand; 1] = [LogCommand];
-            let StdoutTrimmed(stdout) = (log_commands, Split("echo foo"))
-                .run_result_with_context(context.clone())
-                .unwrap();
+            let StdoutTrimmed(stdout) =
+                run_result_with_context((log_commands, Split("echo foo")), context.clone())
+                    .unwrap();
             assert_eq!(stdout, "foo");
             assert_eq!(context.stderr(), "+ echo foo\n");
         }
@@ -679,9 +678,9 @@ mod tests {
         fn slices_of_non_strings() {
             let context = Context::test();
             let log_commands: &[LogCommand] = &[LogCommand];
-            let StdoutTrimmed(stdout) = (log_commands, Split("echo foo"))
-                .run_result_with_context(context.clone())
-                .unwrap();
+            let StdoutTrimmed(stdout) =
+                run_result_with_context((log_commands, Split("echo foo")), context.clone())
+                    .unwrap();
             assert_eq!(stdout, "foo");
             assert_eq!(context.stderr(), "+ echo foo\n");
         }
@@ -794,9 +793,8 @@ mod tests {
         #[test]
         fn does_not_relay_stdout_when_collecting_into_string() {
             let context = Context::test();
-            let StdoutTrimmed(_) = Split("echo foo")
-                .run_result_with_context(context.clone())
-                .unwrap();
+            let StdoutTrimmed(_) =
+                run_result_with_context(Split("echo foo"), context.clone()).unwrap();
             assert_eq!(context.stdout(), "");
         }
 
@@ -804,7 +802,7 @@ mod tests {
         fn does_not_relay_stdout_when_collecting_into_result_of_string() {
             let context = Context::test();
             let _: Result<StdoutTrimmed, Error> =
-                Split("echo foo").run_result_with_context(context.clone());
+                run_result_with_context(Split("echo foo"), context.clone());
             assert_eq!(context.stdout(), "");
         }
     }
@@ -825,8 +823,10 @@ mod tests {
         #[test]
         fn relays_stderr_for_non_zero_exit_codes() {
             let context = Context::test();
-            let _: Result<(), Error> = (test_helper(), "write to stderr and exit with 42")
-                .run_result_with_context(context.clone());
+            let _: Result<(), Error> = run_result_with_context(
+                (test_helper(), "write to stderr and exit with 42"),
+                context.clone(),
+            );
             assert_eq!(context.stderr(), "foo\n");
         }
 
@@ -888,9 +888,9 @@ mod tests {
         #[test]
         fn does_not_relay_stderr_when_catpuring() {
             let context = Context::test();
-            let Stderr(_) = (test_helper(), "write to stderr")
-                .run_result_with_context(context.clone())
-                .unwrap();
+            let Stderr(_) =
+                run_result_with_context((test_helper(), "write to stderr"), context.clone())
+                    .unwrap();
             assert_eq!(context.stderr(), "");
         }
     }
@@ -1142,9 +1142,8 @@ mod tests {
             #[test]
             fn does_not_relay_stdout() {
                 let context = Context::test();
-                let StdoutTrimmed(_) = Split("echo foo")
-                    .run_result_with_context(context.clone())
-                    .unwrap();
+                let StdoutTrimmed(_) =
+                    run_result_with_context(Split("echo foo"), context.clone()).unwrap();
                 assert_eq!(context.stdout(), "");
             }
         }
@@ -1167,9 +1166,8 @@ mod tests {
             #[test]
             fn does_not_relay_stdout() {
                 let context = Context::test();
-                let StdoutUntrimmed(_) = Split("echo foo")
-                    .run_result_with_context(context.clone())
-                    .unwrap();
+                let StdoutUntrimmed(_) =
+                    run_result_with_context(Split("echo foo"), context.clone()).unwrap();
                 assert_eq!(context.stdout(), "");
             }
         }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -46,7 +46,7 @@ macro_rules! run {
 #[macro_export]
 macro_rules! run_output {
     ($($args:tt)*) => {{
-      $crate::input::Input::run_output($crate::tuple_up!($($args)*))
+        $crate::input::Input::run_output($crate::tuple_up!($($args)*))
     }}
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -15,7 +15,7 @@
 #[macro_export]
 macro_rules! run {
     ($($args:tt)*) => {{
-        let () = $crate::run_output!($($args)*);
+        $crate::input::Input::run($crate::tuple_up!($($args)*))
     }}
 }
 
@@ -46,8 +46,7 @@ macro_rules! run {
 #[macro_export]
 macro_rules! run_output {
     ($($args:tt)*) => {{
-        let context = $crate::context::Context::production();
-        $crate::error::panic_on_error($crate::run_result_with_context!(context, $($args)*))
+      $crate::input::Input::run_output($crate::tuple_up!($($args)*))
     }}
 }
 
@@ -56,38 +55,8 @@ macro_rules! run_output {
 #[macro_export]
 macro_rules! run_result {
     ($($args:tt)*) => {{
-        let context = $crate::context::Context::production();
-        $crate::run_result_with_context!(context, $($args)*)
-    }}
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! run_result_with_context {
-    ($context:expr, $($args:tt)*) => {{
-        let mut config = $crate::config::Config::default();
-        $crate::configure!(config: config, args: $($args)*);
-        $crate::child_output::ChildOutput::run_child_process_output($context, config)
-    }}
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! configure {
-    (config: $config:ident, args: % $last:expr $(,)?) => {
-        $crate::input::Input::configure($crate::input::Split($last), &mut $config);
-    };
-    (config: $config:ident, args: $last:expr $(,)?) => {
-        $crate::input::Input::configure($last, &mut $config);
-    };
-    (config: $config:ident, args: % $head:expr, $($tail:tt)*) => {
-        $crate::input::Input::configure($crate::input::Split($head), &mut $config);
-        $crate::configure!(config: $config, args: $($tail)*);
-    };
-    (config: $config:ident, args: $head:expr, $($tail:tt)*) => {
-        $crate::input::Input::configure($head, &mut $config);
-        $crate::configure!(config: $config, args: $($tail)*);
-    };
+        $crate::input::Input::run_result($crate::tuple_up!($($args)*))
+    }};
 }
 
 #[doc(hidden)]
@@ -100,10 +69,10 @@ macro_rules! tuple_up {
         $last
     };
     (% $head:expr, $($tail:tt)*) => {
-        ($crate::input::Split($head), tuple_up!($($tail)*))
+        ($crate::input::Split($head), $crate::tuple_up!($($tail)*))
     };
     ($head:expr, $($tail:tt)*) => {
-        ($head, tuple_up!($($tail)*))
+        ($head, $crate::tuple_up!($($tail)*))
     };
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -84,6 +84,7 @@ mod tests {
         use super::*;
 
         #[test]
+        #[allow(clippy::eq_op)]
         fn one_value() {
             assert_eq!(tuple_up!(1), 1);
         }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -56,7 +56,7 @@ macro_rules! run_output {
 macro_rules! run_result {
     ($($args:tt)*) => {{
         $crate::input::Input::run_result($crate::tuple_up!($($args)*))
-    }};
+    }}
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
This PR implements the macros `run!`, `run_output!` and `run_result!` in terms of the methods on `Input` and in turn implements the methods on `Input` in terms of the functionality from `child_output`. And moves some code around to hopefully make more sense. This also means that some internal functions don't have to be public anymore, because they won't show up in code generated by the macros. Therefore, this is technically a breaking change. All the items that were changed to non-public now were `#[doc(hidden)]` before.