### PR TITLE
Re-export everything from cradle::prelude from the root module too

### DIFF
--- a/src/common_re_exports.rs.snippet
+++ b/src/common_re_exports.rs.snippet
@@ -1,0 +1,10 @@
+// This file contains common re-exports included in both `src/lib.rs` and `src/prelude.rs`.
+// Putting these into a common file ensures that they stay in sync.
+//
+// Note that the macros defined in `src/macros.rs` are already exported from the root module.
+// So they can't be included here, since that would clash.
+pub use crate::{
+    error::Error,
+    input::{CurrentDir, Env, Input, LogCommand, Split, Stdin},
+    output::{Output, Status, Stderr, StdoutTrimmed, StdoutUntrimmed},
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,7 +241,7 @@ mod macros;
 pub mod output;
 pub mod prelude;
 
-pub use crate::error::Error;
+include!("common_re_exports.rs.snippet");
 
 #[cfg(test)]
 mod tests {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,9 +6,5 @@
 //! For documentation about how to use cradle,
 //! see the documentation in the [crate root](crate).
 
-pub use crate::{
-    error::Error,
-    input::{CurrentDir, Env, Input, LogCommand, Split, Stdin},
-    output::{Output, Status, Stderr, StdoutTrimmed, StdoutUntrimmed},
-    run, run_output, run_result,
-};
+include!("common_re_exports.rs.snippet");
+pub use crate::{run, run_output, run_result};

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -324,6 +324,25 @@ mod run_interface {
     }
 }
 
+#[test]
+fn root_re_exports_everything_from_the_prelude() {
+    // This does not import everything that we want to be re-exported from the root module,
+    // but items that are hopefully good test proxies for everything.
+
+    // run macros
+    #[allow(unused_imports)]
+    use cradle::{run, run_output, run_result};
+    // items from input
+    #[allow(unused_imports)]
+    use cradle::{CurrentDir, Input};
+    // items from output
+    #[allow(unused_imports)]
+    use cradle::{Output, Status};
+    // the cradle error type
+    #[allow(unused_imports)]
+    use cradle::Error;
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn memory_test() {


### PR DESCRIPTION
Fixes #155.

This is a weird solution using `include!`. I'm not aware of a better solution that also makes sure that the re-exports from `prelude` and the root module stay in sync.