### PR TITLE
Remove comment about api instability

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,5 @@
 #![deny(missing_debug_implementations)]
 
-//! (`cradle` is in an early stage of development.
-//! APIs may change drastically!
-//! Use at your own risk!)
-//!
 //! `cradle` provides the [`run!`] macro, that makes
 //! it easy to run child processes from rust programs.
 //!


### PR DESCRIPTION
I do expect normal API churn from now on, no drastic changes. So I think it'd be ok to remove this warning. Especially since the versions still start with `0.0.`.

One thing that may happen soon is to allow users to write their own `Input` and `Output` impls. But that should only change parts of the API that are currently `#[doc(hidden)]`.