### PR TITLE
Allow to implement custom impls for `Input`

### DIFF
--- a/justfile
+++ b/justfile
@@ -33,6 +33,6 @@ render-readme-check:
 
 forbidden-words:
   ! grep -rni \
-    'dbg!\|fixme\|todo\|ignore' \
+    'dbg!\|fixme\|todo\|#\[ignore\]' \
     src tests examples
   @echo No forbidden words found

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@
 
 use std::{ffi::OsString, path::PathBuf, sync::Arc};
 
-/// Internal type that configures how to run a child process.
+/// Used by `Input` implementations to configure how child processes are run.
 /// Usually you don't have to use this type directly.
 ///
 /// See also [Custom `Input` impls](crate::Input#custom-input-impls).

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,10 @@
 
 use std::{ffi::OsString, path::PathBuf, sync::Arc};
 
-#[doc(hidden)]
+/// Internal type that configures how to run a child process.
+/// Usually you don't have to use this type directly.
+///
+/// See also [Custom `Input` impls](crate::Input#custom-input-impls).
 #[rustversion::attr(since(1.48), allow(clippy::rc_buffer))]
 #[derive(Debug, Clone)]
 pub struct Config {

--- a/src/input.rs
+++ b/src/input.rs
@@ -98,10 +98,8 @@ use std::{
 ///
 /// ## Custom [`Input`] impls
 ///
-/// For most use-cases, it's not needed to write your own impls
-/// for the [`Input`] trait.
-/// But sometimes it can be helpful, e.g. when you're writing helper
-/// functions around `cradle`.
+/// The provided `Input` implementations should be sufficient for most use cases,
+/// but custom `Input` implementations can be written to extend `cradle`.
 /// Here's an example of an `InContainer` struct, that makes it easy to
 /// run commands in a [`podman`](https://podman.io/) container,
 /// without taking away the flexibility that `cradle` provides:

--- a/src/input.rs
+++ b/src/input.rs
@@ -100,6 +100,7 @@ use std::{
 ///
 /// The provided `Input` implementations should be sufficient for most use cases,
 /// but custom `Input` implementations can be written to extend `cradle`.
+///
 /// Here's an example of an `InContainer` struct, that makes it easy to
 /// run commands in a [`podman`](https://podman.io/) container,
 /// without taking away the flexibility that `cradle` provides:

--- a/src/input.rs
+++ b/src/input.rs
@@ -102,8 +102,7 @@ use std::{
 /// but custom `Input` implementations can be written to extend `cradle`.
 ///
 /// Here's an example of an `InContainer` struct, that makes it easy to
-/// run commands in a [`podman`](https://podman.io/) container,
-/// without taking away the flexibility that `cradle` provides:
+/// run commands in a [`podman`](https://podman.io/) container:
 ///
 /// ```
 /// # #[cfg(target_os = "linux")]

--- a/src/input.rs
+++ b/src/input.rs
@@ -105,10 +105,13 @@ use std::{
 /// Here's an example that
 ///
 /// ```
+/// # #[cfg(linux)]
+/// # {
 /// use cradle::prelude::*;
 ///
 /// let StdoutTrimmed(output) = run_output!(%"podman run ubuntu:21.04 echo foo");
 /// assert_eq!(output, "foo");
+/// # }
 /// ```
 pub trait Input: Sized {
     #[doc(hidden)]

--- a/src/input.rs
+++ b/src/input.rs
@@ -104,7 +104,7 @@ use std::{
 /// functions around `cradle`.
 /// Here's an example of an `InContainer` struct, that makes it easy to
 /// run commands in a [`podman`](https://podman.io/) container,
-/// and all without taking away the flexibility that `cradle` provides:
+/// without taking away the flexibility that `cradle` provides:
 ///
 /// ```
 /// # #[cfg(target_os = "linux")]

--- a/src/input.rs
+++ b/src/input.rs
@@ -95,6 +95,21 @@ use std::{
 /// let hex = to_hex((Stdin(&[14, 15, 16]), Stdin(&[17, 18, 19])));
 /// assert_eq!(hex, "0E0F10111213");
 /// ```
+///
+/// ## Custom [`Input`] impls
+///
+/// For most use-cases, it's not needed to write your own impls
+/// for the [`Input`] trait.
+/// But sometimes it can be helpful, e.g. when you're writing helper
+/// functions around `cradle`.
+/// Here's an example that
+///
+/// ```
+/// use cradle::prelude::*;
+///
+/// let StdoutTrimmed(output) = run_output!(%"podman run ubuntu:21.04 echo foo");
+/// assert_eq!(output, "foo");
+/// ```
 pub trait Input: Sized {
     #[doc(hidden)]
     fn configure(self, config: &mut Config);

--- a/src/input.rs
+++ b/src/input.rs
@@ -130,6 +130,18 @@ use std::{
 /// assert!(output.starts_with("apk-tools 2.12.7, compiled for x86_64."));
 /// # }
 /// ```
+///
+/// It is not recommended to override [`run`](Input::run),
+/// [`run_output`](Input::run_output) or [`run_result`](Input::run_result).
+///
+/// Also note that all fields of the type [`Config`] are private.
+/// That means that when you're writing your own [`Input`] impls,
+/// you _have_ to implement the [`Input::configure`] method
+/// of your type in terms of the [`Input::configure`] methods
+/// of the various [`Input`] types that `cradle` provides --
+/// as demonstrated in the code snippet above.
+/// [`Config`]'s fields are private to allow to add new features to `cradle`
+/// without breaking API changes.
 pub trait Input: Sized {
     /// Configures the given [`Config`](crate::config::Config) for the [`Input`] `self`.
     /// Usually you won't have to write your own custom impls for [`Input`],

--- a/src/input.rs
+++ b/src/input.rs
@@ -147,6 +147,7 @@ pub trait Input: Sized {
     /// Usually you won't have to write your own custom impls for [`Input`],
     /// nor call this function yourself.
     /// So you can safely ignore this method.
+    ///
     /// See also [Custom `Input` impls](#custom-input-impls).
     fn configure(self, config: &mut Config);
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -141,7 +141,7 @@ use std::{
 /// of the various [`Input`] types that `cradle` provides --
 /// as demonstrated in the code snippet above.
 /// [`Config`]'s fields are private to allow to add new features to `cradle`
-/// without breaking API changes.
+/// without introducing breaking API changes.
 pub trait Input: Sized {
     /// Configures the given [`Config`](crate::config::Config) for the [`Input`] `self`.
     /// Usually you won't have to write your own custom impls for [`Input`],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,6 @@
 #[doc(hidden)]
 pub mod child_output;
 mod collected_output;
-#[doc(hidden)]
 pub mod config;
 mod context;
 pub mod error;


### PR DESCRIPTION
One open question: Currently the `configure` methods in the `Input` impls are all `#[doc(hidden)]`. Which makes some sense, since users are usually not going to call those. But since the method is unhidden in the trait now, maybe we should also unhide the impl methods?

Update: I just tried to unhide `configure` in the impls and it causes the doc comments for the impls to be collapsed. So you have to click a little `+` to see them (and the configure method). So I think that would be worse.