### PR TITLE
Rename from_run_result to from_child_output

### DIFF
--- a/src/child_output.rs
+++ b/src/child_output.rs
@@ -28,7 +28,7 @@ impl ChildOutput {
     {
         <T as Output>::configure(&mut config);
         let result = ChildOutput::run_child_process(context, &config)?;
-        T::from_run_result(&config, result)
+        T::from_child_output(&config, result)
     }
 
     fn run_child_process<Stdout, Stderr>(

--- a/src/output.rs
+++ b/src/output.rs
@@ -56,7 +56,7 @@ pub trait Output: Sized {
     fn configure(config: &mut Config);
 
     #[doc(hidden)]
-    fn from_run_result(config: &Config, result: ChildOutput) -> Result<Self, Error>;
+    fn from_child_output(config: &Config, result: ChildOutput) -> Result<Self, Error>;
 }
 
 /// Use this when you don't need any result from the child process.
@@ -80,7 +80,7 @@ impl Output for () {
     fn configure(_config: &mut Config) {}
 
     #[doc(hidden)]
-    fn from_run_result(_config: &Config, _child_output: ChildOutput) -> Result<Self, Error> {
+    fn from_child_output(_config: &Config, _child_output: ChildOutput) -> Result<Self, Error> {
         Ok(())
     }
 }
@@ -97,9 +97,9 @@ macro_rules! tuple_impl {
             }
 
             #[doc(hidden)]
-            fn from_run_result(config: &Config, child_output: ChildOutput) -> Result<Self, Error> {
+            fn from_child_output(config: &Config, child_output: ChildOutput) -> Result<Self, Error> {
                 Ok((
-                    $(<$generics as Output>::from_run_result(config, child_output.clone())?,)+
+                    $(<$generics as Output>::from_child_output(config, child_output.clone())?,)+
                 ))
             }
         }
@@ -143,8 +143,8 @@ impl Output for StdoutTrimmed {
     }
 
     #[doc(hidden)]
-    fn from_run_result(config: &Config, child_output: ChildOutput) -> Result<Self, Error> {
-        let StdoutUntrimmed(stdout) = StdoutUntrimmed::from_run_result(config, child_output)?;
+    fn from_child_output(config: &Config, child_output: ChildOutput) -> Result<Self, Error> {
+        let StdoutUntrimmed(stdout) = StdoutUntrimmed::from_child_output(config, child_output)?;
         Ok(StdoutTrimmed(stdout.trim().to_owned()))
     }
 }
@@ -167,7 +167,7 @@ impl Output for StdoutUntrimmed {
     }
 
     #[doc(hidden)]
-    fn from_run_result(config: &Config, child_output: ChildOutput) -> Result<Self, Error> {
+    fn from_child_output(config: &Config, child_output: ChildOutput) -> Result<Self, Error> {
         let stdout = child_output
             .stdout
             .ok_or_else(|| Error::internal("stdout not captured", config))?;
@@ -207,7 +207,7 @@ impl Output for Stderr {
     }
 
     #[doc(hidden)]
-    fn from_run_result(config: &Config, child_output: ChildOutput) -> Result<Self, Error> {
+    fn from_child_output(config: &Config, child_output: ChildOutput) -> Result<Self, Error> {
         let stderr = child_output
             .stderr
             .ok_or_else(|| Error::internal("stderr not captured", config))?;
@@ -258,7 +258,7 @@ impl Output for Status {
     }
 
     #[doc(hidden)]
-    fn from_run_result(_config: &Config, child_output: ChildOutput) -> Result<Self, Error> {
+    fn from_child_output(_config: &Config, child_output: ChildOutput) -> Result<Self, Error> {
         Ok(Status(child_output.exit_status))
     }
 }
@@ -297,7 +297,7 @@ impl Output for bool {
     }
 
     #[doc(hidden)]
-    fn from_run_result(_config: &Config, child_output: ChildOutput) -> Result<Self, Error> {
+    fn from_child_output(_config: &Config, child_output: ChildOutput) -> Result<Self, Error> {
         Ok(child_output.exit_status.success())
     }
 }


### PR DESCRIPTION
`ChildOutput` was once called `RunResult`, but this trait method wasn't renamed when the type was renamed.