### PR TITLE
Simplify Error type

### DIFF
--- a/src/child_output.rs
+++ b/src/child_output.rs
@@ -5,7 +5,6 @@ use std::{
     ffi::OsString,
     io::Write,
     process::{Command, ExitStatus, Stdio},
-    sync::Arc,
 };
 
 #[doc(hidden)]
@@ -56,14 +55,11 @@ impl ChildOutput {
         if let Some(working_directory) = &config.working_directory {
             command.current_dir(working_directory);
         }
-        let mut child = command.spawn().map_err(|error| {
-            if error.kind() == std::io::ErrorKind::NotFound {
-                Error::FileNotFound {
-                    executable,
-                    source: Arc::new(error),
-                }
+        let mut child = command.spawn().map_err(|source| {
+            if source.kind() == std::io::ErrorKind::NotFound {
+                Error::FileNotFound { executable, source }
             } else {
-                Error::command_io_error(config, error)
+                Error::command_io_error(config, source)
             }
         })?;
         let waiter = Waiter::spawn_standard_stream_relaying(

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,7 +1,7 @@
 //! The [`Output`] trait that defines all possible outputs of a child process.
 
 use crate::{child_output::ChildOutput, config::Config, error::Error};
-use std::{process::ExitStatus, sync::Arc};
+use std::process::ExitStatus;
 
 /// All possible return types of [`run!`], [`run_output!`] or
 /// [`run_result!`] must implement this trait.
@@ -174,7 +174,7 @@ impl Output for StdoutUntrimmed {
         Ok(StdoutUntrimmed(String::from_utf8(stdout).map_err(
             |source| Error::InvalidUtf8ToStdout {
                 full_command: config.full_command(),
-                source: Arc::new(source),
+                source,
             },
         )?))
     }
@@ -214,7 +214,7 @@ impl Output for Stderr {
         Ok(Stderr(String::from_utf8(stderr).map_err(|source| {
             Error::InvalidUtf8ToStderr {
                 full_command: config.full_command(),
-                source: Arc::new(source),
+                source,
             }
         })?))
     }


### PR DESCRIPTION
`Error` needed to implement `Clone` at some point, but it doesn't anymore. So it can be simplified a bit.