### PR TITLE
Don't clone `ChildOutput` for tuple `Output`s

### DIFF
--- a/src/child_output.rs
+++ b/src/child_output.rs
@@ -27,8 +27,8 @@ impl ChildOutput {
         T: Output,
     {
         <T as Output>::configure(&mut config);
-        let result = ChildOutput::run_child_process(context, &config)?;
-        T::from_run_result(&config, result)
+        let child_output = ChildOutput::run_child_process(context, &config)?;
+        T::from_run_result(&config, &child_output)
     }
 
     fn run_child_process<Stdout, Stderr>(


### PR DESCRIPTION
Before this PR we would pass `ChildOutput` not by reference and then had to clone it in a few places. For example in the tuple implementations. Consider this example:
```rust
let (StdoutUntrimmed(a), Stderr(b), Status(c)) = run!("...");
```
Here we would clone `ChildOutput` (including the complete captured `stdout` and `stderr`) 3 times, for every tuple component.

This PR changes that to only clone `stdout` once when `StdoutUntrimmed` is created and `stderr` once when `Stderr` is created.

This is not strictly better though. In this example we would **not** have to clone before, but now we do:
```rust
let StdoutUntrimmed(a) = run!("...");
```

I still think that this is probably a good change.