### PR TITLE
Improve documentation for `Output`

### DIFF
--- a/src/child_output.rs
+++ b/src/child_output.rs
@@ -11,6 +11,9 @@ use std::{
 
 /// Internal type to capture all the outputs of a child process.
 /// Usually you don't have to use this type directly.
+///
+/// See also the documentation for
+/// [Custom `Output` impls](crate::Output#custom-output-impls).
 #[derive(Clone, Debug)]
 pub struct ChildOutput {
     pub(crate) stdout: Option<Vec<u8>>,

--- a/src/child_output.rs
+++ b/src/child_output.rs
@@ -1,3 +1,5 @@
+//! An internal module used for the outputs of child processes.
+
 use crate::{
     collected_output::Waiter, config::Config, context::Context, error::Error, output::Output,
 };
@@ -7,7 +9,8 @@ use std::{
     process::{Command, ExitStatus, Stdio},
 };
 
-#[doc(hidden)]
+/// Internal type to capture all the outputs of a child process.
+/// Usually you don't have to use this type directly.
 #[derive(Clone, Debug)]
 pub struct ChildOutput {
     pub(crate) stdout: Option<Vec<u8>>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,8 +5,9 @@ use std::{ffi::OsString, path::PathBuf, sync::Arc};
 /// Used by `Input` implementations to configure how child processes are run.
 /// Usually you don't have to use this type directly.
 ///
-/// See also [Custom `Input` impls](crate::Input#custom-input-impls).
-/// fixme: mention output
+/// See also the documentation for
+/// [Custom `Input` impls](crate::Input#custom-input-impls) and
+/// [Custom `Output` impls](crate::Output#custom-output-impls).
 #[rustversion::attr(since(1.48), allow(clippy::rc_buffer))]
 #[derive(Debug, Clone)]
 pub struct Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@ use std::{ffi::OsString, path::PathBuf, sync::Arc};
 /// Usually you don't have to use this type directly.
 ///
 /// See also [Custom `Input` impls](crate::Input#custom-input-impls).
+/// fixme: mention output
 #[rustversion::attr(since(1.48), allow(clippy::rc_buffer))]
 #[derive(Debug, Clone)]
 pub struct Config {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,6 @@
 //! [`cmd`](https://hackage.haskell.org/package/shake-0.19.4/docs/Development-Shake.html#v:cmd)
 //! function.
 
-#[doc(hidden)]
 pub mod child_output;
 mod collected_output;
 pub mod config;

--- a/src/output.rs
+++ b/src/output.rs
@@ -62,8 +62,17 @@ use std::process::ExitStatus;
 /// [Issue 184: Provide a better API for writing custom Output impls](https://github.com/soenkehahn/cradle/issues/184)
 /// for more details and discussion.
 pub trait Output: Sized {
+    /// Configures the given [`Config`](crate::config::Config) for the [`Output`] type.
+    /// This is an internal function that should be ignored.
+    ///
+    /// See also [Custom `Output` impls](crate::Output#custom-output-impls).
     fn configure(config: &mut Config);
 
+    /// Converts [`ChildOutput`](crate::child_output::ChildOutput)s
+    /// from running a child process into values of the [`Output`] type.
+    /// This is an internal function that should be ignored.
+    ///
+    /// See also [Custom `Output` impls](crate::Output#custom-output-impls).
     fn from_child_output(config: &Config, result: &ChildOutput) -> Result<Self, Error>;
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -54,7 +54,7 @@ use std::process::ExitStatus;
 ///
 /// ## Custom [`Output`] impls
 ///
-/// It is possible, but not recommended, to write `Output` implementations for your
+/// It is possible, but not recommended, to write [`Output`] implementations for your
 /// own types. The API is inconvenient, under-documented, and easy to misuse, i.e
 /// easy to provoke [`Internal`](Error::Internal) errors.
 ///

--- a/src/output.rs
+++ b/src/output.rs
@@ -54,55 +54,16 @@ use std::process::ExitStatus;
 ///
 /// ## Custom [`Output`] impls
 ///
-/// Usually you don't have to write your own impls for the [`Output`] trait.
-/// There's some uncommon situations where it might be beneficial.
-/// Here's a simple example:
+/// It is not recommended to write `Output` impls for your own types.
+/// In theory it is possible, but the API is
 ///
-/// ```
-/// use cradle::{child_output::ChildOutput, config::Config, prelude::*};
-/// use std::process::ExitStatus;
+/// - not designed to do that conveniently,
+/// - underdocumented and
+/// - easy to misuse, i.e. it is possible to provoke [`Internal`](Error::Internal)
+///   errors.
 ///
-/// struct CommandOutput {
-///     stdout: String,
-///     stderr: String,
-///     status: ExitStatus,
-/// }
-///
-/// impl Output for CommandOutput {
-///     fn configure(config: &mut Config) {
-///       StdoutUntrimmed::configure(config);
-///       Stderr::configure(config);
-///       Status::configure(config);
-///     }
-///
-///     fn from_run_result(
-///         config: &Config,
-///         child_output: ChildOutput,
-///     ) -> Result<Self, Error> {
-///         let StdoutUntrimmed(stdout) =
-///             StdoutUntrimmed::from_run_result(config, child_output.clone())?;
-///         let Stderr(stderr) = Stderr::from_run_result(config, child_output.clone())?;
-///         let Status(status) = Status::from_run_result(config, child_output)?;
-///         Ok(
-///             CommandOutput {
-///                 stdout,
-///                 stderr,
-///                 status,
-///             }
-///         )
-///     }
-/// }
-///
-/// let output: CommandOutput = run_output!(%"echo foo");
-/// assert_eq!(output.stdout, "foo\n");
-/// assert_eq!(output.stderr, "");
-/// assert!(output.status.success());
-/// ```
-///
-/// todo:
-/// - implement in terms of
-/// - fields of config and childoutput are private
-/// - call configure on the same types that you are using in from_run_result, otherwise Internal
+/// See also
+/// [Issue 184: Provide a better API for writing custom Output impls](https://github.com/soenkehahn/cradle/issues/184).
 pub trait Output: Sized {
     fn configure(config: &mut Config);
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -54,16 +54,13 @@ use std::process::ExitStatus;
 ///
 /// ## Custom [`Output`] impls
 ///
-/// It is not recommended to write `Output` impls for your own types.
-/// In theory it is possible, but the API is
+/// It is possible, but not recommended, to write `Output` implementations for your
+/// own types. The API is inconvenient, under-documented, and easy to misuse, i.e
+/// easy to provoke [`Internal`](Error::Internal) errors.
 ///
-/// - not designed to do that conveniently,
-/// - underdocumented and
-/// - easy to misuse, i.e. it is possible to provoke [`Internal`](Error::Internal)
-///   errors.
-///
-/// See also
-/// [Issue 184: Provide a better API for writing custom Output impls](https://github.com/soenkehahn/cradle/issues/184).
+/// See
+/// [Issue 184: Provide a better API for writing custom Output impls](https://github.com/soenkehahn/cradle/issues/184)
+/// for more details and discussion.
 pub trait Output: Sized {
     fn configure(config: &mut Config);
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -55,8 +55,9 @@ use std::process::ExitStatus;
 /// ## Custom [`Output`] impls
 ///
 /// It is possible, but not recommended, to write [`Output`] implementations for your
-/// own types. The API is inconvenient, under-documented, and easy to misuse, i.e
-/// easy to provoke [`Internal`](Error::Internal) errors.
+/// own types.
+/// The API is inconvenient, under-documented, and easy to misuse,
+/// i.e. it is easily possible to provoke [`Internal`](Error::Internal) errors.
 ///
 /// See
 /// [Issue 184: Provide a better API for writing custom Output impls](https://github.com/soenkehahn/cradle/issues/184)


### PR DESCRIPTION
I tried to come up with a good example for a custom impl for the `Output` trait, but that turned out to be a bit more involved. I also realized that when using `cradle` I never really found myself in a position where I wanted to be able to write a custom `Output` impl. So the examples that I came up with were rather made-up. (I often wanted a new `Output` impl within `cradle`, but that doesn't require a nice api to write `Output` impls outside of it.) So I put this PR together, that at least documents that this is currently not really recommended. The documentation also links to #184, which invites people to speak up when they find use-cases for this.