### PR TITLE
Allow only `&'static str` in `Split`

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -329,9 +329,6 @@ impl Input for String {
 ///
 /// let StdoutTrimmed(output) = run_output!(Split("echo foo"));
 /// assert_eq!(output, "foo");
-///
-/// let StdoutTrimmed(output) = run_output!(Split(format!("echo {}", 100)));
-/// assert_eq!(output, "100");
 /// ```
 ///
 /// Since this is such a common case, `cradle` also provides a syntactic shortcut
@@ -346,12 +343,12 @@ impl Input for String {
 ///
 /// [`split_whitespace`]: str::split_whitespace
 #[derive(Debug, PartialEq, Clone)]
-pub struct Split<T: AsRef<str>>(pub T);
+pub struct Split(pub &'static str);
 
-impl<T: AsRef<str>> Input for crate::input::Split<T> {
+impl Input for crate::input::Split {
     #[doc(hidden)]
     fn configure(self, config: &mut Config) {
-        for argument in self.0.as_ref().split_whitespace() {
+        for argument in self.0.split_whitespace() {
             argument.configure(config);
         }
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -366,7 +366,7 @@ impl Input for crate::input::Split {
 /// Arguments to [`split`] must be of type [`char`].
 ///
 /// [`split`]: str::split
-impl<'a> Input for std::str::Split<'a, char> {
+impl Input for std::str::Split<'static, char> {
     #[doc(hidden)]
     fn configure(self, config: &mut Config) {
         for word in self {
@@ -385,7 +385,7 @@ impl<'a> Input for std::str::Split<'a, char> {
 /// ```
 ///
 /// [`split_whitespace`]: str::split_whitespace
-impl<'a> Input for std::str::SplitWhitespace<'a> {
+impl Input for std::str::SplitWhitespace<'static> {
     #[doc(hidden)]
     fn configure(self, config: &mut Config) {
         for word in self {
@@ -404,7 +404,7 @@ impl<'a> Input for std::str::SplitWhitespace<'a> {
 /// ```
 ///
 /// [`split_ascii_whitespace`]: str::split_ascii_whitespace
-impl<'a> Input for std::str::SplitAsciiWhitespace<'a> {
+impl Input for std::str::SplitAsciiWhitespace<'static> {
     #[doc(hidden)]
     fn configure(self, config: &mut Config) {
         for word in self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1170,12 +1170,6 @@ mod tests {
         }
 
         #[test]
-        fn splits_owned_strings() {
-            let StdoutTrimmed(output) = run_output!(Split("echo foo".to_string()));
-            assert_eq!(output, "foo");
-        }
-
-        #[test]
         fn skips_multiple_whitespace_characters() {
             let StdoutUntrimmed(output) = run_output!("echo", Split("foo  bar"));
             assert_eq!(output, "foo bar\n");


### PR DESCRIPTION
This narrows down the types allowed as arguments to `Split` (and therefore the types of values after `%` in macros). The reasoning is that
- this has hardly any downsides, since `Split` is meant as a convenience for working with string literals,
- it prevents surprising behavior in some corner-cases, for an example see https://github.com/matklad/cradle-of-tar.

For more discussion, see https://www.reddit.com/r/rust/comments/poqlo9/cradle_run_child_processes_with_ease/hd00yla/?utm_source=reddit&utm_medium=web2x&context=3.

Do we have any reasonable usecases where arguments to `Split` are not `&'static str`?