### PR TITLE
Derive Copy for input::LogCommand

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -507,7 +507,7 @@ where
 /// run!(LogCommand, %"echo foo");
 /// // writes '+ echo foo' to stderr
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct LogCommand;
 
 impl Input for LogCommand {


### PR DESCRIPTION
I ran into an ownership error message with `LogCommand` in another project. It can be easily worked around by using `&LogCommand`, but I thought deriving `Copy` also is a good idea.

@casey: Do you know whether this would be a minor or a major version bump? (I wouldn't necessarily cut a release for this though.)