### PR TITLE
Provide `Input` and `Output` impls for tuples up to size 16

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -439,6 +439,22 @@ tuple_impl!(0, A, 1, B, 2, C, 3, D,);
 tuple_impl!(0, A, 1, B, 2, C, 3, D, 4, E,);
 tuple_impl!(0, A, 1, B, 2, C, 3, D, 4, E, 5, F,);
 tuple_impl!(0, A, 1, B, 2, C, 3, D, 4, E, 5, F, 6, G,);
+tuple_impl!(0, A, 1, B, 2, C, 3, D, 4, E, 5, F, 6, G, 7, H,);
+tuple_impl!(0, A, 1, B, 2, C, 3, D, 4, E, 5, F, 6, G, 7, H, 8, I,);
+tuple_impl!(0, A, 1, B, 2, C, 3, D, 4, E, 5, F, 6, G, 7, H, 8, I, 9, J,);
+tuple_impl!(0, A, 1, B, 2, C, 3, D, 4, E, 5, F, 6, G, 7, H, 8, I, 9, J, 10, K,);
+tuple_impl!(0, A, 1, B, 2, C, 3, D, 4, E, 5, F, 6, G, 7, H, 8, I, 9, J, 10, K, 11, L,);
+tuple_impl!(0, A, 1, B, 2, C, 3, D, 4, E, 5, F, 6, G, 7, H, 8, I, 9, J, 10, K, 11, L, 12, M,);
+tuple_impl!(
+    0, A, 1, B, 2, C, 3, D, 4, E, 5, F, 6, G, 7, H, 8, I, 9, J, 10, K, 11, L, 12, M, 13, N,
+);
+tuple_impl!(
+    0, A, 1, B, 2, C, 3, D, 4, E, 5, F, 6, G, 7, H, 8, I, 9, J, 10, K, 11, L, 12, M, 13, N, 14, O,
+);
+tuple_impl!(
+    0, A, 1, B, 2, C, 3, D, 4, E, 5, F, 6, G, 7, H, 8, I, 9, J, 10, K, 11, L, 12, M, 13, N, 14, O,
+    15, P,
+);
 
 /// All elements of the given [`Vec`] are used as arguments to the child process.
 /// Same as passing in the elements separately.

--- a/src/output.rs
+++ b/src/output.rs
@@ -130,6 +130,16 @@ tuple_impl!(A, B, C,);
 tuple_impl!(A, B, C, D,);
 tuple_impl!(A, B, C, D, E,);
 tuple_impl!(A, B, C, D, E, F,);
+tuple_impl!(A, B, C, D, E, F, G,);
+tuple_impl!(A, B, C, D, E, F, G, H,);
+tuple_impl!(A, B, C, D, E, F, G, H, I,);
+tuple_impl!(A, B, C, D, E, F, G, H, I, J,);
+tuple_impl!(A, B, C, D, E, F, G, H, I, J, K,);
+tuple_impl!(A, B, C, D, E, F, G, H, I, J, K, L,);
+tuple_impl!(A, B, C, D, E, F, G, H, I, J, K, L, M,);
+tuple_impl!(A, B, C, D, E, F, G, H, I, J, K, L, M, N,);
+tuple_impl!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O,);
+tuple_impl!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P,);
 
 /// Returns what the child process writes to `stdout`, interpreted as utf-8,
 /// collected into a string, trimmed of leading and trailing whitespace.


### PR DESCRIPTION
I started using `Split` (or `%`) less and started using tuples more and ran into this limit.