### PR TITLE
Refactor panic source location tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,6 @@ name = "test_executables_helper"
 path = "src/test_executables/helper.rs"
 required-features = ["test_executables"]
 
-[[bin]]
-name = "test_executables_panic"
-path = "src/test_executables/panic.rs"
-required-features = ["test_executables"]
-
 [target.'cfg(unix)'.dependencies.gag]
 version = "0.1.10"
 optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,20 +365,6 @@ mod tests {
                 run!(without_executable_bit, %"foo bar");
             }
 
-            #[rustversion::since(1.46)]
-            #[test]
-            fn includes_source_location_of_run_run_call() {
-                let (Status(_), Stderr(stderr)) =
-                    run_output!(test_executable("test_executables_panic"));
-                let expected = "src/test_executables/panic.rs:4:5";
-                assert!(
-                    stderr.contains(expected),
-                    "{:?}\n  does not contain\n{:?}",
-                    stderr,
-                    expected
-                );
-            }
-
             #[test]
             #[should_panic(expected = "cradle error: no arguments given")]
             fn no_executable() {

--- a/src/test_executables/panic.rs
+++ b/src/test_executables/panic.rs
@@ -1,5 +1,0 @@
-use cradle::*;
-
-fn main() {
-    run!("false");
-}

--- a/tests/panic_source_locations.rs
+++ b/tests/panic_source_locations.rs
@@ -1,7 +1,6 @@
-#[allow(unused_imports)]
+#[rustversion::since(1.46)]
 use cradle::prelude::*;
-#[allow(unused_imports)]
-use pretty_assertions::assert_eq;
+#[rustversion::since(1.46)]
 use std::{
     panic::{set_hook, take_hook},
     sync::{Arc, Mutex},
@@ -13,18 +12,18 @@ fn panics_contain_source_locations_of_run_and_run_output_call() {
     let f = || run!("false");
     let panic_location = get_panic_location(f);
     assert_eq!(
-        Some("tests/panic_source_locations.rs:13:16".to_string()),
+        Some("tests/panic_source_locations.rs:12:16".to_string()),
         panic_location
     );
     let f = || run_output!("false");
     let panic_location = get_panic_location(f);
     assert_eq!(
-        Some("tests/panic_source_locations.rs:19:16".to_string()),
+        Some("tests/panic_source_locations.rs:18:16".to_string()),
         panic_location
     );
 }
 
-#[allow(dead_code)]
+#[rustversion::since(1.46)]
 fn get_panic_location(f: fn()) -> Option<String> {
     let mutex: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
     let mutex_clone = mutex.clone();

--- a/tests/panic_source_locations.rs
+++ b/tests/panic_source_locations.rs
@@ -29,7 +29,7 @@ fn get_panic_location(f: fn()) -> Option<String> {
     let mutex_clone = mutex.clone();
     set_hook(Box::new(move |info| {
         let mut guard = mutex_clone.lock().unwrap();
-        *guard = info.location().map(|x| x.clone().to_string());
+        *guard = info.location().map(ToString::to_string);
     }));
     let _ = std::panic::catch_unwind(f);
     let _ = take_hook();

--- a/tests/panic_source_locations.rs
+++ b/tests/panic_source_locations.rs
@@ -1,0 +1,39 @@
+#[allow(unused_imports)]
+use cradle::prelude::*;
+#[allow(unused_imports)]
+use pretty_assertions::assert_eq;
+use std::{
+    panic::{set_hook, take_hook},
+    sync::{Arc, Mutex},
+};
+
+#[rustversion::since(1.46)]
+#[test]
+fn panics_contain_source_locations_of_run_and_run_output_call() {
+    let f = || run!("false");
+    let panic_location = get_panic_location(f);
+    assert_eq!(
+        Some("tests/panic_source_locations.rs:13:16".to_string()),
+        panic_location
+    );
+    let f = || run_output!("false");
+    let panic_location = get_panic_location(f);
+    assert_eq!(
+        Some("tests/panic_source_locations.rs:19:16".to_string()),
+        panic_location
+    );
+}
+
+#[allow(dead_code)]
+fn get_panic_location(f: fn()) -> Option<String> {
+    let mutex: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let mutex_clone = mutex.clone();
+    set_hook(Box::new(move |info| {
+        let mut guard = mutex_clone.lock().unwrap();
+        *guard = info.location().map(|x| x.clone().to_string());
+    }));
+    let _ = std::panic::catch_unwind(f);
+    let _ = take_hook();
+    let guard = mutex.lock().unwrap();
+    guard.clone()
+}


### PR DESCRIPTION
This PR gets rid of the `test_executables_panic` executable, while re-implementing the same tests in a different way. I think this is better since the executable is not meant for users of the library and as such ideally shouldn't show up in the `Cargo.toml` file.

(I also would like to get rid of `test_executables_helper` at some point.)