### PR TITLE
Do not run system-dependent examples

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -27,7 +27,7 @@ pub enum Error {
     /// A `file not found` error occurred while trying to spawn
     /// the child process:
     ///
-    /// ```
+    /// ```no_run
     /// use cradle::prelude::*;
     ///
     /// let result: Result<(), Error> = run_result!("does-not-exist");
@@ -61,7 +61,7 @@ pub enum Error {
     CommandIoError { message: String, source: io::Error },
     /// The child process exited with a non-zero exit code.
     ///
-    /// ```
+    /// ```no_run
     /// use cradle::prelude::*;
     ///
     /// let result: Result<(), cradle::Error> = run_result!("false");

--- a/src/input.rs
+++ b/src/input.rs
@@ -20,7 +20,7 @@ use std::{
 /// For example you can pass in an executable as a String,
 /// and a variable number of arguments as a [`Vec`]:
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let executable = "echo";
@@ -55,7 +55,7 @@ use std::{
 /// `cradle` also implements [`Input`] for tuples of types that themselves implement [`Input`].
 /// Instead of passing multiple arguments to [`run!`], they can be passed in a single tuple:
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let args = ("echo", "foo");
@@ -65,7 +65,7 @@ use std::{
 ///
 /// This can be used to group arguments:
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let to_hex_command = ("xxd", "-ps", "-u", LogCommand);
@@ -75,7 +75,7 @@ use std::{
 ///
 /// Also, tuples make it possible to write wrappers around [`run!`] without requiring the use of macros:
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// fn to_hex<I: Input>(input: I) -> String {
@@ -105,7 +105,7 @@ use std::{
 /// [`BTreeMap`](std::collections::BTreeMap) and adds all contained
 /// key-value pairs to the environment of the child process.
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 /// use cradle::config::Config;
 /// use std::collections::BTreeMap;
@@ -163,7 +163,7 @@ pub trait Input: Sized {
     /// `input.run()` runs `input` as a child process.
     /// It's equivalent to `run!(input)`.
     ///
-    /// ```
+    /// ```no_run
     /// # let temp_dir = tempfile::TempDir::new().unwrap();
     /// # std::env::set_current_dir(&temp_dir).unwrap();
     /// use cradle::prelude::*;
@@ -178,7 +178,7 @@ pub trait Input: Sized {
     /// `input.run()` runs `input` as a child process.
     /// It's equivalent to `run_output!(input)`.
     ///
-    /// ```
+    /// ```no_run
     /// use cradle::prelude::*;
     ///
     /// let StdoutTrimmed(output) = ("echo", "foo").run_output();
@@ -195,7 +195,7 @@ pub trait Input: Sized {
     /// `input.run_result()` runs `input` as a child process.
     /// It's equivalent to `run_result!(input)`.
     ///
-    /// ```
+    /// ```no_run
     /// use cradle::prelude::*;
     ///
     /// # fn build() -> Result<(), Error> {
@@ -258,7 +258,7 @@ where
 /// Arguments of type [`OsString`] are passed to the child process
 /// as arguments.
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// run!("ls", std::env::var_os("HOME").unwrap());
@@ -273,7 +273,7 @@ impl Input for OsString {
 /// Arguments of type [`&OsStr`] are passed to the child process
 /// as arguments.
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// run!("echo", std::env::current_dir().unwrap().file_name().unwrap());
@@ -290,7 +290,7 @@ impl Input for &OsStr {
 /// Arguments of type [`&str`] are passed to the child process as arguments.
 /// This is especially useful because it allows you to use string literals:
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let StdoutTrimmed(output) = run_output!("echo", "foo");
@@ -306,7 +306,7 @@ impl Input for &str {
 /// Arguments of type [`String`] are passed to the child process
 /// as arguments. Executables can also be passed as [`String`]s:
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let executable: String = "echo".to_string();
@@ -324,7 +324,7 @@ impl Input for String {
 /// Splits the contained string by whitespace (using [`split_whitespace`])
 /// and uses the resulting words as separate arguments.
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let StdoutTrimmed(output) = run_output!(Split("echo foo"));
@@ -334,7 +334,7 @@ impl Input for String {
 /// Since this is such a common case, `cradle` also provides a syntactic shortcut
 /// for [`Split`], the `%` symbol:
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let StdoutTrimmed(output) = run_output!(%"echo foo");
@@ -356,7 +356,7 @@ impl Input for crate::input::Split {
 
 /// Allows to use [`split`] to split your argument into words:
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let StdoutTrimmed(output) = run_output!("echo foo".split(' '));
@@ -377,7 +377,7 @@ impl Input for std::str::Split<'static, char> {
 
 /// Allows to use [`split_whitespace`] to split your argument into words:
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let StdoutTrimmed(output) = run_output!("echo foo".split_whitespace());
@@ -396,7 +396,7 @@ impl Input for std::str::SplitWhitespace<'static> {
 
 /// Allows to use [`split_ascii_whitespace`] to split your argument into words:
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let StdoutTrimmed(output) = run_output!("echo foo".split_ascii_whitespace());
@@ -459,7 +459,7 @@ tuple_impl!(
 /// All elements of the given [`Vec`] are used as arguments to the child process.
 /// Same as passing in the elements separately.
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let StdoutTrimmed(output) = run_output!(vec!["echo", "foo"]);
@@ -480,7 +480,7 @@ where
 /// Similar to the implementation for [`Vec<T>`].
 /// All elements of the array will be used as arguments.
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let StdoutTrimmed(output) = run_output!(["echo", "foo"]);
@@ -526,7 +526,7 @@ where
 /// to log the commands (including all arguments) to `stderr`.
 /// (This is similar `bash`'s `-x` option.)
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// run!(LogCommand, %"echo foo");
@@ -545,7 +545,7 @@ impl Input for LogCommand {
 /// By default child processes inherit the current directory from their
 /// parent. You can override this with [`CurrentDir`]:
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// # #[cfg(target_os = "linux")]
@@ -572,7 +572,7 @@ where
 /// Arguments of type [`PathBuf`] are passed to the child process
 /// as arguments.
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 /// use std::path::PathBuf;
 ///
@@ -589,7 +589,7 @@ impl Input for PathBuf {
 /// Arguments of type [`&Path`] are passed to the child process
 /// as arguments.
 ///
-/// ```
+/// ```no_run
 /// # let temp_dir = tempfile::TempDir::new().unwrap();
 /// # std::env::set_current_dir(&temp_dir).unwrap();
 /// use cradle::prelude::*;
@@ -609,7 +609,7 @@ impl Input for &Path {
 
 /// Writes the given byte slice to the child's standard input.
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// # #[cfg(target_os = "linux")]
@@ -643,7 +643,7 @@ where
 
 /// Adds an environment variable to the environment of the child process.
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let StdoutUntrimmed(output) = run_output!("env", Env("FOO", "bar"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! `cradle` provides the [`run!`] macro, that makes
 //! it easy to run child processes from rust programs.
 //!
-//! ```
+//! ```no_run
 //! # let temp_dir = tempfile::TempDir::new().unwrap();
 //! # std::env::set_current_dir(&temp_dir).unwrap();
 //! use cradle::prelude::*;
@@ -18,7 +18,7 @@
 //! You can pass in multiple arguments (of different types) to [`run!`]
 //! to specify arguments, as long as they implement the [`Input`] trait:
 //!
-//! ```
+//! ```no_run
 //! # let temp_dir = tempfile::TempDir::new().unwrap();
 //! # std::env::set_current_dir(&temp_dir).unwrap();
 //! use cradle::prelude::*;
@@ -41,7 +41,7 @@
 //! to collect what the child process writes to `stdout`,
 //! trimmed of leading and trailing whitespace:
 //!
-//! ```
+//! ```no_run
 //! use cradle::prelude::*;
 //!
 //! let StdoutTrimmed(output) = run_output!(%"echo foo");
@@ -54,7 +54,7 @@
 //! If you don't want any result from [`run_output!`], you can use `()`
 //! as the return value:
 //!
-//! ```
+//! ```no_run
 //! # let temp_dir = tempfile::TempDir::new().unwrap();
 //! # std::env::set_current_dir(&temp_dir).unwrap();
 //! use cradle::prelude::*;
@@ -66,7 +66,7 @@
 //! that we've already seen above.
 //! It behaves exactly like [`run_output!`] but always returns `()`:
 //!
-//! ```
+//! ```no_run
 //! # let temp_dir = tempfile::TempDir::new().unwrap();
 //! # std::env::set_current_dir(&temp_dir).unwrap();
 //! use cradle::prelude::*;
@@ -81,7 +81,7 @@
 //! `cradle` does *not* split given string arguments on whitespace by default.
 //! So for example this code fails:
 //!
-//! ``` should_panic
+//! ```no_run
 //! use cradle::prelude::*;
 //!
 //! let StdoutTrimmed(_) = run_output!("echo foo");
@@ -92,7 +92,7 @@
 //! That fails, because an executable with that name doesn't exist.
 //! `cradle` provides a new-type wrapper [`Split`] to help with that:
 //!
-//! ```
+//! ```no_run
 //! use cradle::prelude::*;
 //!
 //! let StdoutTrimmed(output) = run_output!(Split("echo foo"));
@@ -106,7 +106,7 @@
 //! And -- since this is such a common case -- `cradle` provides a syntactic shortcut
 //! for [`Split`], the `%` symbol:
 //!
-//! ```
+//! ```no_run
 //! use cradle::prelude::*;
 //!
 //! let StdoutTrimmed(output) = run_output!(%"echo foo");
@@ -127,7 +127,7 @@
 //! where more complex error handling is not needed or desired,
 //! for example in scripts.
 //!
-//! ``` should_panic
+//! ```no_run
 //! use cradle::prelude::*;
 //!
 //! // panics with "false:\n  exited with exit code: 1"
@@ -145,7 +145,7 @@
 //! `T` is any type that implements [`output::Output`].
 //! Here's some examples:
 //!
-//! ```
+//! ```no_run
 //! use cradle::prelude::*;
 //!
 //! let result: Result<(), cradle::Error> = run_result!("false");
@@ -163,7 +163,7 @@
 //! [`run_result!`] can also be combined with `?` to handle errors in an
 //! idiomatic way, for example:
 //!
-//! ```
+//! ```no_run
 //! use cradle::prelude::*;
 //!
 //! fn build() -> Result<(), Error> {
@@ -192,7 +192,7 @@
 //! They work analog to [`run!`], [`run_output!`] and [`run_result!`].
 //! Here are some examples:
 //!
-//! ```
+//! ```no_run
 //! # let temp_dir = tempfile::TempDir::new().unwrap();
 //! # std::env::set_current_dir(&temp_dir).unwrap();
 //! use cradle::prelude::*;
@@ -213,7 +213,7 @@
 //! Note: The `%` shortcut for [`Split`] is not available in this notation.
 //! You can either use tuples, or [`Split`] explicitly:
 //!
-//! ```
+//! ```no_run
 //! use cradle::prelude::*;
 //!
 //! ("echo", "foo").run();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,6 +1,6 @@
 /// Executes a child process without capturing any output.
 ///
-/// ```
+/// ```no_run
 /// # let temp_dir = tempfile::TempDir::new().unwrap();
 /// # std::env::set_current_dir(&temp_dir).unwrap();
 /// use cradle::prelude::*;
@@ -22,7 +22,7 @@ macro_rules! run {
 /// Execute child processes, and capture some output.
 /// For example you can capture what the child process writes to stdout:
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let StdoutUntrimmed(output) = run_output!(%"echo foo");
@@ -34,7 +34,7 @@ macro_rules! run {
 /// you can control what outputs of child processes you want to capture.
 /// Here's an example to capture an exit code:
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let Status(status) = run_output!("false");

--- a/src/output.rs
+++ b/src/output.rs
@@ -9,7 +9,7 @@ use std::process::ExitStatus;
 /// For example, if you want to capture what a command writes
 /// to `stdout` you can do that using [`StdoutUntrimmed`]:
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let StdoutUntrimmed(output) = run_output!(%"echo foo");
@@ -19,7 +19,7 @@ use std::process::ExitStatus;
 /// But if instead you want to capture the command's [`ExitStatus`],
 /// you can use [`Status`]:
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let Status(exit_status) = run_output!("false");
@@ -42,7 +42,7 @@ use std::process::ExitStatus;
 /// The following code for example retrieves the command's [`ExitStatus`]
 /// _and_ what it writes to `stdout`:
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let (Status(exit_status), StdoutUntrimmed(stdout)) = run_output!(%"echo foo");
@@ -79,7 +79,7 @@ pub trait Output: Sized {
 
 /// Use this when you don't need any result from the child process.
 ///
-/// ```
+/// ```no_run
 /// # let temp_dir = tempfile::TempDir::new().unwrap();
 /// # std::env::set_current_dir(&temp_dir).unwrap();
 /// use cradle::prelude::*;
@@ -151,7 +151,7 @@ tuple_impl!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P,);
 /// This will make sure that the return type can be inferred.
 /// Here's an example:
 ///
-/// ```
+/// ```no_run
 /// use std::path::Path;
 /// use cradle::prelude::*;
 ///
@@ -179,7 +179,7 @@ impl Output for StdoutTrimmed {
 
 /// Same as [`StdoutTrimmed`], but does not trim whitespace from the output:
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let StdoutUntrimmed(output) = run_output!(%"echo foo");
@@ -211,7 +211,7 @@ impl Output for StdoutUntrimmed {
 
 /// [`Stderr`] allows to capture the `stderr` of a child process:
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// // (`Status` is used here to suppress panics caused by `ls`
@@ -253,7 +253,7 @@ impl Output for Stderr {
 /// Use [`Status`] as the return type for [`run_output!`] to retrieve the
 /// [`ExitStatus`] of the child process:
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let Status(exit_status) = run_output!(%"echo foo");
@@ -265,7 +265,7 @@ impl Output for Stderr {
 /// [`run_output!`]) nor an [`std::result::Result::Err`]
 /// (when used with [`run_result!`]):
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let Status(exit_status) = run_output!("false");
@@ -296,7 +296,7 @@ impl Output for Status {
 /// Using [`bool`] as the return type for [`run_output!`] will return `true` if
 /// the command returned successfully, and `false` otherwise:
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// if !run_output!(%"which cargo") {
@@ -307,7 +307,7 @@ impl Output for Status {
 /// Also, when using [`bool`], non-zero exit codes will not result in a panic
 /// or [`std::result::Result::Err`]:
 ///
-/// ```
+/// ```no_run
 /// use cradle::prelude::*;
 ///
 /// let success: bool = run_output!("false");


### PR DESCRIPTION
Hello!

I'm packaging _just_ on GNU Guix and found some friction when packaging this crate<sup>[1]</sup> (Guix needs all dependencies to be compiled an tested) because it requires access to some executables that are system dependent, so I've marked some of the doc-tests to not run (but will be compiled) so testing can be done on GNU Guix (each build is a container with minimal utilities needed to compile the source code with the additional dependencies).

[1]: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=56663

Also I've relaxed the version requirements on `Cargo.toml`, this to make maintenance easier on GNU Guix side as some of the dependencies might not be on the latest released version. (crates are updated but it's a slow process and maybe some crates have semver breaking changes). To overcome the MSRV issue on the CI, I pinned the `bitflags` crate on the GitHub workflow.