### PR TITLE
Add Output implementation for deserializing JSON

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,17 @@ keywords = ["child", "child-process", "command", "process", "shell"]
 categories = ["filesystem", "os"]
 exclude = ["/.github"]
 
+[features]
+serde = ["dep:serde", "dep:serde_json"]
+test_executables = ["nix", "serde"]
+
 [workspace]
 members = [".", "context-integration-tests", "memory-tests"]
 
 [dependencies]
 rustversion = "1.0.4"
-serde = "1.0.196"
-serde_json = "1.0.113"
+serde = { version = "1.0.196", optional = true }
+serde_json = {version = "1.0.113", optional = true }
 
 [dev-dependencies]
 executable-path = "1.0.0"
@@ -33,7 +37,7 @@ bitflags = "=1.2.1"
 [[bin]]
 name = "test_executables_helper"
 path = "src/test_executables/helper.rs"
-required-features = ["test_executables"]
+required-features = ["test_executables", "serde"]
 
 [[bin]]
 name = "test_executables_panic"
@@ -43,6 +47,3 @@ required-features = ["test_executables"]
 [target.'cfg(unix)'.dependencies.nix]
 version = "0.22.2"
 optional = true
-
-[features]
-test_executables = ["nix"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ members = [".", "context-integration-tests", "memory-tests"]
 
 [dependencies]
 rustversion = "1.0.4"
+serde = "1.0.196"
+serde_json = "1.0.113"
 
 [dev-dependencies]
 executable-path = "1.0.0"

--- a/context-integration-tests/Cargo.toml
+++ b/context-integration-tests/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2018"
 publish = false
 
 [target.'cfg(unix)'.dependencies]
-cradle = { path = ".." }
+cradle = { path = "..", features = ["serde"] }
 executable-path = "1.0.0"
 gag = "0.1.10"

--- a/justfile
+++ b/justfile
@@ -50,3 +50,6 @@ all-rustc-versions *args="ci":
     cargo version
     just {{ args }}
   done
+
+watch +args='test':
+  cargo watch --clear --exec '{{args}}'

--- a/memory-tests/Cargo.toml
+++ b/memory-tests/Cargo.toml
@@ -6,5 +6,5 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.42"
-cradle = { path = ".." }
+cradle = { path = "..", features = ["serde"] }
 rustversion = "1.0.5"

--- a/src/common_re_exports.rs.snippet
+++ b/src/common_re_exports.rs.snippet
@@ -6,5 +6,5 @@
 pub use crate::{
     error::Error,
     input::{CurrentDir, Env, Input, LogCommand, Split, Stdin},
-    output::{Output, Status, Stderr, StdoutTrimmed, StdoutUntrimmed},
+    output::{Output, Status, Stderr, StdoutTrimmed, StdoutUntrimmed, Json},
 };

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,9 @@ pub enum Error {
     /// }
     /// ```
     NoExecutableGiven,
+    Deserialize {
+        source: serde_json::Error,
+    },
     /// A `file not found` error occurred while trying to spawn
     /// the child process:
     ///
@@ -58,7 +61,10 @@ pub enum Error {
     /// - reading from `stdout` or `stderr` of the child process fails,
     /// - writing to the parent's `stdout` or `stderr` fails,
     /// - the given executable doesn't have the executable flag set.
-    CommandIoError { message: String, source: io::Error },
+    CommandIoError {
+        message: String,
+        source: io::Error,
+    },
     /// The child process exited with a non-zero exit code.
     ///
     /// ```
@@ -176,6 +182,7 @@ impl Display for Error {
         use Error::*;
         match self {
             NoExecutableGiven => write!(f, "no arguments given"),
+            Deserialize { source } => write!(f, "JSON deserialization failed: {source}"),
             FileNotFound { executable, .. } => {
                 let executable = executable.to_string_lossy();
                 write!(f, "File not found error when executing '{}'", executable)?;
@@ -223,6 +230,7 @@ impl std::error::Error for Error {
         use Error::*;
         match self {
             FileNotFound { source, .. } | CommandIoError { source, .. } => Some(source),
+            Deserialize { source } => Some(source),
             InvalidUtf8ToStdout { source, .. } | InvalidUtf8ToStderr { source, .. } => Some(source),
             NoExecutableGiven | NonZeroExitCode { .. } | Internal { .. } => None,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1494,4 +1494,21 @@ mod tests {
             }
         }
     }
+
+    #[cfg(feature = "serde")]
+    mod json {
+        use super::*;
+
+        #[test]
+        fn json_can_be_deserialized() {
+            let Json(bar): Json<u32> = run_output!("echo", "100");
+            assert_eq!(bar, 100);
+        }
+
+        #[test]
+        fn json_errors() {
+            let Json(bar): Json<u32> = run_output!("echo", "null");
+            assert_eq!(bar, 100);
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1507,8 +1507,7 @@ mod tests {
 
         #[test]
         fn json_errors() {
-            let Json(bar): Json<u32> = run_output!("echo", "null");
-            assert_eq!(bar, 100);
+            let result: Result<Json<u32>, Error> = run_result!("echo", "null");
         }
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,8 +1,10 @@
 //! The [`Output`] trait that defines all possible outputs of a child process.
 
-use crate::{child_output::ChildOutput, config::Config, error::Error};
-use serde::de::DeserializeOwned;
-use std::process::ExitStatus;
+use {
+    crate::{child_output::ChildOutput, config::Config, error::Error},
+    serde::de::DeserializeOwned,
+    std::process::ExitStatus,
+};
 
 /// All possible return types of [`run!`], [`run_output!`] or
 /// [`run_result!`] must implement this trait.
@@ -179,7 +181,7 @@ impl Output for StdoutTrimmed {
 }
 
 #[derive(Debug)]
-pub struct Json<T: DeserializeOwned>(T);
+pub struct Json<T: DeserializeOwned>(pub T);
 
 impl<T: DeserializeOwned> Output for Json<T> {
     #[doc(hidden)]


### PR DESCRIPTION
I figured that cradle was probably lonely from not having a PR for a while, so I decided to help.

I'm running a bunch of commands (`ord` and `bitcoin-cli`) which return JSON on standard output.

This PR adds a `Json` struct, which wraps any type that implements deserialize, and deserializes the command's standard output into an instance of that type. It's kind of unfortunate to have an output type which is specific to JSON, and not something that can be used to deserialize anything, but as far as I know, serde doesn't provide a trait which allows you to abstract over serialization formats, so I think adding a struct for each serialization format is the way.

`serde` and `serde_json` are pretty heavy dependencies, and `cradle` currently has no dependencies other than `rustversion`, so it might be wise to put this behind an optional, default-off feature flag.

(You will notice that there are no tests, and I can thus hear you clutching your pearls, but I promise to write some if you think this is a good idea!)