### PR TITLE
Link to the Haskell version of cradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ operating system's interface for running child processes.
 
 ## MSRV
 The minimal supported rust version is `0.41`.
+
+## Related Software
+
+- [`cradle` for Haskell](https://github.com/garnix-io/cradle#readme): The same ideas from the same people in another good language.


### PR DESCRIPTION
I was looking for the Haskell library, but (because I knew @soenkehahn was the author) I found this one instead and thought “oh, this is the name of the Rust crate, I must have been thinking of something else”.

I think having the same name across languages is good, but then they should also cross-link so you can quickly get to the right one from the other (I’m opening a similar PR against the Haskell package).